### PR TITLE
feat: implemented i18n translation support for fi/en

### DIFF
--- a/algojkl-frontend/package-lock.json
+++ b/algojkl-frontend/package-lock.json
@@ -14,9 +14,11 @@
         "contentful": "^11.5.7",
         "contentful-management": "^11.52.1",
         "dotenv": "^16.5.0",
+        "i18next": "^26.3.6",
         "react": "^19.2.1",
         "react-burger-menu": "^3.1.0",
         "react-dom": "^19.2.1",
+        "react-i18next": "^17.0.11",
         "react-icons": "^4.12.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.3.0"
@@ -269,9 +271,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2929,6 +2931,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://locize.com"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2937,6 +2948,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -4241,6 +4280,33 @@
         "react": "^19.2.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^4.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -4856,6 +4922,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vfile": {

--- a/algojkl-frontend/package.json
+++ b/algojkl-frontend/package.json
@@ -18,9 +18,11 @@
     "contentful": "^11.5.7",
     "contentful-management": "^11.52.1",
     "dotenv": "^16.5.0",
+    "i18next": "^26.3.6",
     "react": "^19.2.1",
     "react-burger-menu": "^3.1.0",
     "react-dom": "^19.2.1",
+    "react-i18next": "^17.0.11",
     "react-icons": "^4.12.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.3.0"

--- a/algojkl-frontend/src/App.css
+++ b/algojkl-frontend/src/App.css
@@ -240,6 +240,44 @@ h3 {
   padding-right: 1%;
 }
 
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background-color: #faf6ed;
+  border: 2px solid #322c2b;
+  border-radius: 999px;
+  padding: 3px;
+}
+
+.language-toggle button {
+  border: 0;
+  border-radius: 999px;
+  padding: 5px 10px;
+  background: transparent;
+  color: #322c2b;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.language-toggle button:hover {
+  background-color: #fbbebd;
+  color: #000000;
+}
+
+.language-toggle button.active {
+  background-color: #fbbebd;
+  color: #000000;
+  box-shadow: 1px 1px 0 #322c2b;
+}
+
+.language-toggle button:focus-visible {
+  outline: 2px solid #322c2b;
+  outline-offset: 1px;
+}
+
 .right-section ul {
   list-style-type: none;
   display: flex;

--- a/algojkl-frontend/src/PageData/aktiivitData.js
+++ b/algojkl-frontend/src/PageData/aktiivitData.js
@@ -4,7 +4,6 @@ import aktiivi_s from '../images/aktiivit_s.png'
 import aktiivi_1 from '../images/aktiivit_1.png'
 import aktiivi_2 from '../images/aktiivit-2.png'
 import aktiivi_3 from '../images/aktiivi_3.png'
-import { href } from 'react-router-dom'
 
 export const starterImages = { desktop: starterDesktop, mobile: starterMobile }
 

--- a/algojkl-frontend/src/components/Events/EventList.jsx
+++ b/algojkl-frontend/src/components/Events/EventList.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import EventCard from './EventCard'
 
 /**
@@ -6,16 +7,20 @@ import EventCard from './EventCard'
  *
  * Näyttää annetun tapahtumalistauksen.
  */
-const EventList = ({ events, onEventClick }) => (
-  <>
-    {events.length > 0 ? (
-      events.map((event) => (
-        <EventCard key={event.id} event={event} onClick={onEventClick} />
-      ))
-    ) : (
-      <p>Tapahtumia lisätään pian!</p>
-    )}
-  </>
-)
+const EventList = ({ events, onEventClick }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <>
+      {events.length > 0 ? (
+        events.map((event) => (
+          <EventCard key={event.id} event={event} onClick={onEventClick} />
+        ))
+      ) : (
+        <p>{t('pages.events.empty')}</p>
+      )}
+    </>
+  )
+}
 
 export default EventList

--- a/algojkl-frontend/src/components/Events/EventModal.jsx
+++ b/algojkl-frontend/src/components/Events/EventModal.jsx
@@ -1,37 +1,43 @@
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
+import { useTranslation } from 'react-i18next'
 
 /**
  * EventModal
  *
  * Näyttää modaalin yksittäisen tapahtuman tiedoille
  */
-const EventModal = ({ event, onClose }) => (
-  <div className="modal-overlay" onClick={onClose}>
-    <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-      <span className="close" onClick={onClose}>
-        &times;
-      </span>
-      <h2>{event.title}</h2>
-      <ReactMarkdown>{event.description}</ReactMarkdown>
-      {event.url && (
-        <h2 className="modal-tickets">
-          <a href={event.url}>Liput</a>
-        </h2>
-      )}
-      <p>
-        <strong>Päivämäärä:</strong>{' '}
-        {new Date(Date.parse(event.date)).toLocaleDateString('fi-FI')}
-      </p>
-      {event.picture?.fields?.file?.url && (
-        <img
-          src={event.picture.fields.file.url}
-          alt={event.title}
-          className="modal-image"
-        />
-      )}
+const EventModal = ({ event, onClose }) => {
+  const { t, i18n } = useTranslation('common')
+  const dateLocale = i18n.language === 'en' ? 'en-GB' : 'fi-FI'
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <span className="close" onClick={onClose}>
+          &times;
+        </span>
+        <h3>{event.title}</h3>
+        <ReactMarkdown>{event.description}</ReactMarkdown>
+        {event.url && (
+          <p className="modal-tickets">
+            <a href={event.url}>{t('pages.eventModal.tickets')}</a>
+          </p>
+        )}
+        <p>
+          <strong>{t('pages.eventModal.dateLabel')}:</strong>{' '}
+          {new Date(Date.parse(event.date)).toLocaleDateString(dateLocale)}
+        </p>
+        {event.picture?.fields?.file?.url && (
+          <img
+            src={event.picture.fields.file.url}
+            alt={event.title}
+            className="modal-image"
+          />
+        )}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default EventModal

--- a/algojkl-frontend/src/components/Events/LoadMoreButton.jsx
+++ b/algojkl-frontend/src/components/Events/LoadMoreButton.jsx
@@ -1,16 +1,31 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 /**
  * LoadMoreButton
  *
  * Näyttää “näytä lisää / vähemmän” -painikkeen
  */
-const LoadMoreButton = ({ showAll, onClick }) => (
-  <div className="event-card-button">
-    <button onClick={onClick}>
-      {showAll ? 'NÄYTÄ VÄHEMMÄN' : 'NÄYTÄ LISÄÄ TAPAHTUMIA'}
-    </button>
-  </div>
-)
+const LoadMoreButton = ({ showAll, onClick }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="event-card-button">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={
+          showAll
+            ? t('pages.eventCards.showLessAria')
+            : t('pages.eventCards.showMoreAria')
+        }
+      >
+        {showAll
+          ? t('pages.eventCards.showLess')
+          : t('pages.eventCards.showMore')}
+      </button>
+    </div>
+  )
+}
 
 export default LoadMoreButton

--- a/algojkl-frontend/src/components/Footer/FooterFeedback.jsx
+++ b/algojkl-frontend/src/components/Footer/FooterFeedback.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 /**
  * FooterFeedback
  *
@@ -11,20 +12,19 @@ import React from 'react'
  * - feedback: yksittäisen palautelomake-osan sisältö
  */
 const FooterFeedback = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div className="feedback-comms">
       <div className="feedback">
-        <h3>Haluatko antaa meille palautetta?</h3>
-        <p>
-          Se onnistuu, kun täytät alla olevan lomakkeen. Palautteet käsitellään
-          anonyymisti.
-        </p>
+        <h3>{t('footer.feedbackTitle')}</h3>
+        <p>{t('footer.feedbackDescription')}</p>
         <a
           href="https://docs.google.com/forms/d/e/1FAIpQLSd_uGBf6NpWvJi_v3o7w3iJ2flnCMrxnNWMi6hIgMhD3kPBAw/viewform"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Palautelomake
+          {t('footer.feedbackLink')}
         </a>
       </div>
     </div>

--- a/algojkl-frontend/src/components/Footer/FooterInfo.jsx
+++ b/algojkl-frontend/src/components/Footer/FooterInfo.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 /**
  * FooterInfo
  *
@@ -9,18 +10,22 @@ import React from 'react'
  * - Tekijänoikeustiedot
  *
  */
-const FooterInfo = () => (
-  <div className="footer-info">
-    <h2>Algo ry</h2>
-    <p>Yhteystiedot</p>
-    <p>Mattilanniemi 2,</p>
-    <p>40100 Jyväskylä</p>
-    <p>pj@algojkl.com</p>
-    <p>Y-tunnus: 3297709-4</p>
-    <p>
-      <strong>© Algo ry, 2025</strong>
-    </p>
-  </div>
-)
+const FooterInfo = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="footer-info">
+      <h2>{t('nav.brand')}</h2>
+      <p>{t('footer.contactTitle')}</p>
+      <p>{t('footer.addressLine1')}</p>
+      <p>{t('footer.addressLine2')}</p>
+      <p>{t('footer.email')}</p>
+      <p>{t('footer.vat')}</p>
+      <p>
+        <strong>© {t('nav.brand')}, 2025</strong>
+      </p>
+    </div>
+  )
+}
 
 export default FooterInfo

--- a/algojkl-frontend/src/components/Footer/FooterNav.jsx
+++ b/algojkl-frontend/src/components/Footer/FooterNav.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import FooterNavSection from './FooterNavSection1'
 /**
  * FooterNav
@@ -16,61 +17,65 @@ import FooterNavSection from './FooterNavSection1'
  * Mikäli halutaan lisätä linkkejä, niin lisää vain uusia to ja label osioita samaan tyyliin oikean titlen alle.
  *
  */
-const FooterNav = () => (
-  <nav className="footer-nav">
-    <ul>
-      <FooterNavSection
-        title="NAVIGAATIO"
-        links={[
-          { to: '/', label: 'ETUSIVU' },
-          { to: '/tapahtumat', label: 'TAPAHTUMAT' },
-          { to: '/yhteistyot', label: 'YHTEISTYÖT' },
-          { to: '/fuksit', label: 'FUKSIT' },
-          { to: '/hakijalle', label: 'HAKIJAT' },
-        ]}
-      />
-    </ul>
-    <ul>
-      <FooterNavSection
-        title="TOIMIHENKILÖT"
-        links={[
-          { to: '/hallitus', label: 'HALLITUS' },
-          { to: '/aktiivit', label: 'AKTIIVIT' },
-        ]}
-      />
-    </ul>
-    <ul>
-      <FooterNavSection
-        title="VIRALLISET DOKUMENTIT"
-        links={[
-          { to: '/saannot', label: 'SÄÄNNÖT' },
-          { to: '/ohjesaannot', label: 'OHJESÄÄNNÖT' },
-          { to: '/seloste', label: 'REKISTERISELOSTE' },
-          { to: '/dokumentit', label: 'DOKUMENTIT' },
-          { to: '/kunniagalleria', label: 'KUNNIAGALLERIA' },
-          { to: '/periaatteet', label: 'TOIMINNAN PERIAATTEET' },
-        ]}
-      />
-    </ul>
-    <ul>
-      <FooterNavSection
-        title="JÄSENILLE"
-        links={[
-          { to: '/jasenedut', label: 'JÄSENEDUT' },
-          { to: '/kerhotoiminta', label: 'KERHOTOIMINTA' },
-          { to: '/rekryt', label: 'REKRYT' },
-          { to: '/lomakkeet', label: 'LOMAKKEET' },
-          { to: '/kansainvalisyys', label: 'KANSAINVÄLISYYS' },
-          {
-            to: 'https://kattila.linkkijkl.fi/',
-            label: 'KATTILAN KAHVIKAMERA',
-          },
-          { to: '/salaisuudet', label: 'SALAISUUDET' },
-          { to: 'https://ritmi.algojkl.com/', label: 'LAULUKIRJA' },
-        ]}
-      />
-    </ul>
-  </nav>
-)
+const FooterNav = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <nav className="footer-nav">
+      <ul>
+        <FooterNavSection
+          title={t('nav.menu')}
+          links={[
+            { to: '/', label: t('nav.links.home') },
+            { to: '/tapahtumat', label: t('nav.events') },
+            { to: '/yhteistyot', label: t('nav.collaboration') },
+            { to: '/fuksit', label: t('nav.fuksit') },
+            { to: '/hakijalle', label: t('nav.applicants') },
+          ]}
+        />
+      </ul>
+      <ul>
+        <FooterNavSection
+          title={t('nav.sections.staff')}
+          links={[
+            { to: '/hallitus', label: t('nav.links.board') },
+            { to: '/aktiivit', label: t('nav.links.active') },
+          ]}
+        />
+      </ul>
+      <ul>
+        <FooterNavSection
+          title={t('nav.sections.officialDocuments')}
+          links={[
+            { to: '/saannot', label: t('nav.links.rules') },
+            { to: '/ohjesaannot', label: t('nav.links.guidelines') },
+            { to: '/seloste', label: t('nav.links.privacy') },
+            { to: '/dokumentit', label: t('nav.links.documents') },
+            { to: '/kunniagalleria', label: t('nav.links.honours') },
+            { to: '/periaatteet', label: t('nav.links.principles') },
+          ]}
+        />
+      </ul>
+      <ul>
+        <FooterNavSection
+          title={t('nav.sections.members')}
+          links={[
+            { to: '/jasenedut', label: t('nav.links.benefits') },
+            { to: '/kerhotoiminta', label: t('nav.links.clubs') },
+            { to: '/rekryt', label: t('nav.links.recruitment') },
+            { to: '/lomakkeet', label: t('nav.links.formsShort') },
+            { to: '/kansainvalisyys', label: t('nav.links.international') },
+            {
+              to: 'https://kattila.linkkijkl.fi/',
+              label: t('nav.links.kattila'),
+            },
+            { to: '/salaisuudet', label: t('nav.links.secrets') },
+            { to: 'https://ritmi.algojkl.com/', label: t('nav.links.songbook') },
+          ]}
+        />
+      </ul>
+    </nav>
+  )
+}
 
 export default FooterNav

--- a/algojkl-frontend/src/components/Hallihaku/HallitusHaku.jsx
+++ b/algojkl-frontend/src/components/Hallihaku/HallitusHaku.jsx
@@ -1,25 +1,27 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { useHallitusHaku } from './useHallitusHaku'
 import HakuList from './HakuList'
 
 const HallitusHaku = () => {
+  const { t } = useTranslation('common')
   const { isLoading, error, puheenjohtajisto, muutPestit } = useHallitusHaku()
 
-  if (isLoading) return <p>Ladataan hakemuksia...</p>
-  if (error) return <p>Virhe ladatessa hakemuksia</p>
+  if (isLoading) return <p>{t('pages.hallihaku.loading')}</p>
+  if (error) return <p>{t('pages.hallihaku.error')}</p>
 
   return (
     <div className="hallihaku-container">
-      <h2>Puheenjohtajisto</h2>
+      <h2>{t('pages.hallihaku.chair')}</h2>
       <HakuList
         list={puheenjohtajisto}
-        emptyMessage="Ei vielä hakemuksia puheenjohtajistoon."
+        emptyMessage={t('pages.hallihaku.emptyChair')}
       />{' '}
       <br />
-      <h2>Muut hallituspestit</h2>
+      <h2>{t('pages.hallihaku.other')}</h2>
       <HakuList
         list={muutPestit}
-        emptyMessage="Ei vielä hakemuksia muihin hallituspesteihin."
+        emptyMessage={t('pages.hallihaku.emptyOther')}
       />{' '}
       <br />
     </div>

--- a/algojkl-frontend/src/components/HallitusCard/HallitusInfo.jsx
+++ b/algojkl-frontend/src/components/HallitusCard/HallitusInfo.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { memberPropType } from './HallitusPropTypes'
 
 /**
@@ -13,21 +14,25 @@ import { memberPropType } from './HallitusPropTypes'
  * Props:
  *  - member: hallituksen jäsenen tiedot (nimi, pesti, yhteystiedot)
  */
-const HallitusInfo = ({ member }) => (
-  <div className="hallitus-info">
-    <h2>{member.pesti}</h2>
-    {member.lispesti && <p>{member.lispesti}</p>}
-    <p>
-      <strong>{member.nimi}</strong>
-    </p>
-    {member.telegram && <p>Telegram: {member.telegram}</p>}
-    {member.sahkoposti && (
+const HallitusInfo = ({ member }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="hallitus-info">
+      <h2>{member.pesti}</h2>
+      {member.lispesti && <p>{member.lispesti}</p>}
       <p>
-        <a href={`mailto:${member.sahkoposti}`}>{member.sahkoposti}</a>
+        <strong>{member.nimi}</strong>
       </p>
-    )}
-  </div>
-)
+      {member.telegram && <p>{t('pages.hallitus.telegram')} {member.telegram}</p>}
+      {member.sahkoposti && (
+        <p>
+          <a href={`mailto:${member.sahkoposti}`}>{member.sahkoposti}</a>
+        </p>
+      )}
+    </div>
+  )
+}
 
 HallitusInfo.propTypes = {
   member: memberPropType.isRequired,

--- a/algojkl-frontend/src/components/JasenEdutContent/JasenEdutContent.jsx
+++ b/algojkl-frontend/src/components/JasenEdutContent/JasenEdutContent.jsx
@@ -1,16 +1,21 @@
+import { useTranslation } from 'react-i18next'
 import JasenEtuItem from './JasenEtuItem'
 import JasenEdutIntro from './JasenEdutIntro'
 
-const JasenEdutContent = ({ edut }) => (
-  <div className="jasenedut-container">
-    <h2>Jäsenedut</h2>
-    <JasenEdutIntro />
-    {edut.length > 0 ? (
-      edut.map((etu) => <JasenEtuItem key={etu.id} etu={etu} />)
-    ) : (
-      <p>Jäsenetuja lisätään pian!</p>
-    )}
-  </div>
-)
+const JasenEdutContent = ({ edut }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="jasenedut-container">
+      <h2>{t('pages.jasenedut.title')}</h2>
+      <JasenEdutIntro />
+      {edut.length > 0 ? (
+        edut.map((etu) => <JasenEtuItem key={etu.id} etu={etu} />)
+      ) : (
+        <p>{t('pages.jasenedut.empty')}</p>
+      )}
+    </div>
+  )
+}
 
 export default JasenEdutContent

--- a/algojkl-frontend/src/components/JasenEdutContent/JasenEdutIntro.jsx
+++ b/algojkl-frontend/src/components/JasenEdutContent/JasenEdutIntro.jsx
@@ -1,16 +1,19 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
-const JasenEdutIntro = () => (
-  <p className="jasenedut-text">
-    Algo tarjoaa jäsenilleen hienoja etuja! Tsekkaa alta tarkemmin, mihin
-    etuihin Algon jäsenyys sinut oikeuttaa. Jäsenyys todistetaan näyttämällä
-    KideApp-sovelluksesta löytyvä Algon jäsenyys.{' '}
-    <strong>
-      Mikäli alennukseen tarvitaan alekoodi, löytyy ne Algon{' '}
-      <a href="/salaisuudet">salaisuudet-sivulta</a>.
-    </strong>{' '}
-    Salasanan sivuille voit kysyä hallituslaiselta.
-  </p>
-)
+const JasenEdutIntro = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <p className="jasenedut-text">
+      {t('pages.jasenedut.intro')}{' '}
+      <strong>
+        {t('pages.jasenedut.passwords')}{' '}
+        <a href="/salaisuudet">{t('pages.jasenedut.secretsLink')}</a>.
+      </strong>{' '}
+      {t('pages.jasenedut.ask')}
+    </p>
+  )
+}
 
 export default JasenEdutIntro

--- a/algojkl-frontend/src/components/Kerhotoiminta/KerhotSection.jsx
+++ b/algojkl-frontend/src/components/Kerhotoiminta/KerhotSection.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 /**
  * KerhotSection
  *
@@ -11,26 +12,29 @@ import React from 'react'
  *   - linkText: linkin teksti
  */
 
-const KerhotSection = ({ kerhot }) => (
-  <div>
-    <h3>Algon kerhot</h3>
-    {kerhot.map((k, idx) => (
-      <div key={idx}>
-        <p>
-          <strong>{k.name}</strong>
-          <br />
-          {k.description}
-          <br />
-          <br />
-          Lisätietoja kerhosta sekä peliaikatauluista saat liittymällä kerhon
-          Telegram-ryhmään:
-          <a href={k.linkHref} target="_blank" rel="noopener noreferrer">
-            {k.linkText}
-          </a>
-        </p>
-      </div>
-    ))}
-  </div>
-)
+const KerhotSection = ({ kerhot }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div>
+      <h3>{t('pages.kerhotoiminta.sectionTitle')}</h3>
+      {kerhot.map((k, idx) => (
+        <div key={idx}>
+          <p>
+            <strong>{k.name}</strong>
+            <br />
+            {k.description}
+            <br />
+            <br />
+            {t('pages.kerhotoiminta.infoPrefix')}{' '}
+            <a href={k.linkHref} target="_blank" rel="noopener noreferrer">
+              {k.linkText}
+            </a>
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
 
 export default KerhotSection

--- a/algojkl-frontend/src/components/Navigation/LanguageToggle.jsx
+++ b/algojkl-frontend/src/components/Navigation/LanguageToggle.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+const LanguageToggle = () => {
+  const { i18n, t } = useTranslation('common')
+
+  const changeLanguage = (language) => {
+    i18n.changeLanguage(language)
+    localStorage.setItem('algo-language', language)
+  }
+
+  const activeLanguage = i18n.resolvedLanguage?.startsWith('en') ? 'en' : 'fi'
+
+  return (
+    <div className="language-toggle" aria-label={t('nav.language.toggle')}>
+      <button
+        type="button"
+        className={activeLanguage === 'fi' ? 'active' : ''}
+        onClick={() => changeLanguage('fi')}
+      >
+        {t('nav.language.fi')}
+      </button>
+      <button
+        type="button"
+        className={activeLanguage === 'en' ? 'active' : ''}
+        onClick={() => changeLanguage('en')}
+      >
+        {t('nav.language.en')}
+      </button>
+    </div>
+  )
+}
+
+export default LanguageToggle

--- a/algojkl-frontend/src/components/Navigation/NavBar.jsx
+++ b/algojkl-frontend/src/components/Navigation/NavBar.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import NavbarLeft from './NavbarLeft'
 import NavbarRight from './NavbarRight'
 import NavbarMobile from './NavbarMobile'
-import dropdownLinks from './NavbarLinks'
+import getDropdownLinks from './NavbarLinks'
 
 /**
  * NavBar
@@ -17,6 +18,8 @@ import dropdownLinks from './NavbarLinks'
  */
 function NavBar() {
   const [menuOpen, setMenuOpen] = useState(false)
+  const { t } = useTranslation('common')
+  const dropdownLinks = getDropdownLinks(t)
 
   return (
     <>

--- a/algojkl-frontend/src/components/Navigation/NavBarMobileJoin.jsx
+++ b/algojkl-frontend/src/components/Navigation/NavBarMobileJoin.jsx
@@ -1,20 +1,25 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 /**
  * NavbarJoinButton
  *
  * Näyttää “Liity jäseneksi” -napin, joka ohjaa Kide.appiin.
  */
-const NavbarJoinButton = ({ onClick }) => (
-  <button className="jasen_nappi" onClick={onClick}>
-    <a
-      href="https://kide.app/memberships/2a49d555-1856-4ad7-bac6-b1838e7481fc"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      LIITY JÄSENEKSI
-    </a>
-  </button>
-)
+const NavbarJoinButton = ({ onClick }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <button className="jasen_nappi" onClick={onClick}>
+      <a
+        href="https://kide.app/memberships/2a49d555-1856-4ad7-bac6-b1838e7481fc"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {t('nav.joinButton')}
+      </a>
+    </button>
+  )
+}
 
 export default NavbarJoinButton

--- a/algojkl-frontend/src/components/Navigation/NavbarLeft.jsx
+++ b/algojkl-frontend/src/components/Navigation/NavbarLeft.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import logo from './assets/algologo.jpeg'
 import discord from './assets/discord.png'
 import insta from './assets/instagram.png'
@@ -29,23 +30,27 @@ const socialLinks = [
  *
  * Näyttää logon, yhdistyksen nimen ja sosiaalisen median linkit.
  */
-const NavbarLeft = () => (
-  <div className="left-section">
-    <a href="/" className="logo-link">
-      <img src={logo} alt="Algo ry logo" className="logo" />
-    </a>
-    <a href="/" className="kilta">
-      Algo ry
-    </a>
+const NavbarLeft = () => {
+  const { t } = useTranslation('common')
 
-    <div className="social">
-      {socialLinks.map(({ href, icon, alt }, index) => (
-        <a key={index} href={href} target="_blank" rel="noopener noreferrer">
-          <img src={icon} alt={alt} />
-        </a>
-      ))}
+  return (
+    <div className="left-section">
+      <a href="/" className="logo-link">
+        <img src={logo} alt="Algo ry logo" className="logo" />
+      </a>
+      <a href="/" className="kilta">
+        {t('nav.brand')}
+      </a>
+
+      <div className="social">
+        {socialLinks.map(({ href, icon, alt }, index) => (
+          <a key={index} href={href} target="_blank" rel="noopener noreferrer">
+            <img src={icon} alt={alt} />
+          </a>
+        ))}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default NavbarLeft

--- a/algojkl-frontend/src/components/Navigation/NavbarLinks.js
+++ b/algojkl-frontend/src/components/Navigation/NavbarLinks.js
@@ -5,38 +5,38 @@
  * desktop- että mobiiliversioissa Navbarissa.
  */
 
-const dropdownLinks = [
+const getDropdownLinks = (t) => [
   {
-    section: 'TOIMIHENKILÖT',
+    section: t('nav.sections.staff'),
     items: [
-      { label: 'HALLITUS', path: '/hallitus' },
-      { label: 'AKTIIVIT', path: '/aktiivit' },
+      { label: t('nav.links.board'), path: '/hallitus' },
+      { label: t('nav.links.active'), path: '/aktiivit' },
     ],
   },
   {
-    section: 'VIRALLISET DOKUMENTIT',
+    section: t('nav.sections.officialDocuments'),
     items: [
-      { label: 'SÄÄNNÖT', path: '/saannot' },
-      { label: 'OHJESÄÄNNÖT & ETIKETIT', path: '/ohjesaannot' },
-      { label: 'VUOSIJUHLAT', path: '/vujuetiketti' },
-      { label: 'REKISTERISELOSTE', path: '/seloste' },
-      { label: 'KUNNIAGALLERIA', path: '/kunniagalleria' },
-      { label: 'TOIMINNAN PERIAATTEET', path: '/periaatteet' },
+      { label: t('nav.links.rules'), path: '/saannot' },
+      { label: t('nav.links.guidelines'), path: '/ohjesaannot' },
+      { label: t('nav.links.vuju'), path: '/vujuetiketti' },
+      { label: t('nav.links.privacy'), path: '/seloste' },
+      { label: t('nav.links.honours'), path: '/kunniagalleria' },
+      { label: t('nav.links.principles'), path: '/periaatteet' },
     ],
   },
   {
-    section: 'JÄSENILLE',
+    section: t('nav.sections.members'),
     items: [
-      { label: 'JÄSENEDUT', path: '/jasenedut' },
-      { label: 'KERHOTOIMINTA', path: '/kerhotoiminta' },
-      { label: 'REKRYT', path: '/rekryt' },
-      { label: 'YHTEYDENOTTOLOMAKKEET', path: '/lomakkeet' },
-      { label: 'KANSAINVÄLISYYS', path: '/kansainvalisyys' },
-      { label: 'KATTILAN KAHVIKAMERA', path: 'https://kattila.linkkijkl.fi/' },
-      { label: 'SALAISUUDET', path: '/salaisuudet' },
-      { label: 'LAULUKIRJA', path: 'https://ritmi.algojkl.com/' },
+      { label: t('nav.links.benefits'), path: '/jasenedut' },
+      { label: t('nav.links.clubs'), path: '/kerhotoiminta' },
+      { label: t('nav.links.recruitment'), path: '/rekryt' },
+      { label: t('nav.links.forms'), path: '/lomakkeet' },
+      { label: t('nav.links.international'), path: '/kansainvalisyys' },
+      { label: t('nav.links.kattila'), path: 'https://kattila.linkkijkl.fi/' },
+      { label: t('nav.links.secrets'), path: '/salaisuudet' },
+      { label: t('nav.links.songbook'), path: 'https://ritmi.algojkl.com/' },
     ],
   },
 ]
 
-export default dropdownLinks
+export default getDropdownLinks

--- a/algojkl-frontend/src/components/Navigation/NavbarMobile.jsx
+++ b/algojkl-frontend/src/components/Navigation/NavbarMobile.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { slide as Menu } from 'react-burger-menu'
 import DropdownMenu from './dropdown'
 import Panu from '../simple'
 import bursa from './assets/burger_v4.png'
 import NavbarMobileLinks from './NavbarMobileLinks'
 import NavbarJoinButton from './NavBarMobileJoin'
+import LanguageToggle from './LanguageToggle'
 
 /**
  * NavbarMobile
@@ -16,6 +18,7 @@ import NavbarJoinButton from './NavBarMobileJoin'
  *  - Panu-komponentti
  */
 const NavbarMobile = ({ menuOpen, setMenuOpen, dropdownLinks }) => {
+  const { t } = useTranslation('common')
   const handleClose = () => setMenuOpen(false)
 
   return (
@@ -27,13 +30,13 @@ const NavbarMobile = ({ menuOpen, setMenuOpen, dropdownLinks }) => {
     >
       <ul>
         <DropdownMenu
-          title="KILTA"
+          title={t('nav.menu')}
           links={dropdownLinks}
           onItemClick={handleClose}
         />
         <NavbarMobileLinks onClick={handleClose} />
         <NavbarJoinButton onClick={handleClose} />
-        <p>/* -------------------- */</p>
+        <LanguageToggle />
         <Panu />
       </ul>
     </Menu>

--- a/algojkl-frontend/src/components/Navigation/NavbarMobileLinks.jsx
+++ b/algojkl-frontend/src/components/Navigation/NavbarMobileLinks.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
 /**
@@ -6,21 +7,24 @@ import { Link } from 'react-router-dom'
  *
  * Sisältää mobiilivalikon yksittäiset sivulinkit.
  */
-const links = [
-  { path: '/tapahtumat', label: 'TAPAHTUMAT' },
-  { path: '/yhteistyot', label: 'YHTEISTYÖT' },
-  { path: '/fuksit', label: 'FUKSIT' },
-  { path: '/hakijalle', label: 'HAKIJAT' },
-]
+const NavbarMobileLinks = ({ onClick }) => {
+  const { t } = useTranslation('common')
+  const links = [
+    { path: '/tapahtumat', label: t('nav.events') },
+    { path: '/yhteistyot', label: t('nav.collaboration') },
+    { path: '/fuksit', label: t('nav.fuksit') },
+    { path: '/hakijalle', label: t('nav.applicants') },
+  ]
 
-const NavbarMobileLinks = ({ onClick }) => (
-  <>
-    {links.map(({ path, label }) => (
-      <li key={path} className="bm-li" onClick={onClick}>
-        <Link to={path}>{label}</Link>
-      </li>
-    ))}
-  </>
-)
+  return (
+    <>
+      {links.map(({ path, label }) => (
+        <li key={path} className="bm-li" onClick={onClick}>
+          <Link to={path}>{label}</Link>
+        </li>
+      ))}
+    </>
+  )
+}
 
 export default NavbarMobileLinks

--- a/algojkl-frontend/src/components/Navigation/NavbarRight.jsx
+++ b/algojkl-frontend/src/components/Navigation/NavbarRight.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import DropdownMenu from './dropdown'
 import Join from './joinUs'
+import LanguageToggle from './LanguageToggle'
 
 /**
  * NavbarRight
@@ -11,25 +13,30 @@ import Join from './joinUs'
  *  - Yksittäiset linkit
  *  - Panun nappi (jäseneksi liittyminen)
  */
-const NavbarRight = ({ dropdownLinks }) => (
-  <div className="right-section">
-    <ul className="desktop-menu">
-      <DropdownMenu title="KILTA" links={dropdownLinks} />
-      <li>
-        <Link to="/tapahtumat">TAPAHTUMAT</Link>
-      </li>
-      <li>
-        <Link to="/yhteistyot">YHTEISTYÖ</Link>
-      </li>
-      <li>
-        <Link to="/fuksit">FUKSIT</Link>
-      </li>
-      <li>
-        <Link to="/hakijalle">HAKIJAT</Link>
-      </li>
-    </ul>
-    <Join />
-  </div>
-)
+const NavbarRight = ({ dropdownLinks }) => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="right-section">
+      <ul className="desktop-menu">
+        <DropdownMenu title={t('nav.menu')} links={dropdownLinks} />
+        <li>
+          <Link to="/tapahtumat">{t('nav.events')}</Link>
+        </li>
+        <li>
+          <Link to="/yhteistyot">{t('nav.collaboration')}</Link>
+        </li>
+        <li>
+          <Link to="/fuksit">{t('nav.fuksit')}</Link>
+        </li>
+        <li>
+          <Link to="/hakijalle">{t('nav.applicants')}</Link>
+        </li>
+      </ul>
+      <LanguageToggle />
+      <Join />
+    </div>
+  )
+}
 
 export default NavbarRight

--- a/algojkl-frontend/src/components/PersonCard.jsx
+++ b/algojkl-frontend/src/components/PersonCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 /**
  * PersonCard
@@ -10,11 +11,13 @@ import React from 'react'
  * - image: kuvatiedosto (valinnainen)
  */
 const PersonCard = ({ name, year, image, list }) => {
+  const { t } = useTranslation('common')
+
   if (list) {
     return (
       <ul className="kunniajasenet">
         <li>
-          {name} {year && <i>(Nimetty {year})</i>}
+          {name} {year && <i>({t('pages.personCard.named', { year })})</i>}
         </li>
       </ul>
     )
@@ -24,8 +27,8 @@ const PersonCard = ({ name, year, image, list }) => {
     <div className="person-card">
       {image && <img src={image} alt={name} />}
       <div>
-        <p>{name}</p>
-        {year && <small>{year}</small>}
+        <p className="person-card-name">{name}</p>
+        {year && <small className="person-card-year">{year}</small>}
       </div>
     </div>
   )

--- a/algojkl-frontend/src/components/Pestit/PestitDescription.jsx
+++ b/algojkl-frontend/src/components/Pestit/PestitDescription.jsx
@@ -1,30 +1,32 @@
 import React from 'react'
-import Roles from './Pestit'
+import { useTranslation } from 'react-i18next'
 
-const PestitDescription = () => (
-  <div className="hallitus-pesti-info">
-    <h3>Lyhyet kuvaukset hallituspesteistä</h3>
-    <p>
-      {Roles.map((role, i) => (
-        <span key={i}>
-          <strong>{role.title}</strong> {role.description}
-          <br />
-          <br />
-        </span>
-      ))}
-      <i>
-        ps: Hallituksessa tehdään yhteistyössä muitakin kuin vain oman
-        vastuualueen tehtäviä.
-      </i>
-    </p>
+const PestitDescription = () => {
+  const { t } = useTranslation('common')
+  const roles = t('pages.pestit.roles', { returnObjects: true })
 
-    <p>
-      Aiemmat hallitukset näet{' '}
-      <a href="/entiset-hallitukset">
-        <strong>täältä</strong>
-      </a>
-    </p>
-  </div>
-)
+  return (
+    <div className="hallitus-pesti-info">
+      <h3>{t('pages.pestit.title')}</h3>
+      <p>
+        {roles.map((role, i) => (
+          <span key={i}>
+            <strong>{role.title}</strong> {role.description}
+            <br />
+            <br />
+          </span>
+        ))}
+        <i>{t('pages.pestit.ps')}</i>
+      </p>
+
+      <p>
+        {t('pages.pestit.previous')}{' '}
+        <a href="/entiset-hallitukset">
+          <strong>{t('pages.pestit.here')}</strong>
+        </a>
+      </p>
+    </div>
+  )
+}
 
 export default PestitDescription

--- a/algojkl-frontend/src/components/Saannot/Section.jsx
+++ b/algojkl-frontend/src/components/Saannot/Section.jsx
@@ -4,13 +4,47 @@ import React from 'react'
  * Section-komponentti
  * Props:
  * - title: otsikko (string)
- * - content: sisältö (JSX)
+ * - content: sisältö (JSX | string[] | object[])
  */
+const renderContent = (item, idx) => {
+  if (typeof item === 'string') {
+    return <p key={idx}>{item}</p>
+  }
+
+  if (item?.type === 'heading') {
+    return <h5 key={idx}>{item.text}</h5>
+  }
+
+  if (item?.type === 'paragraph') {
+    return <p key={idx}>{item.text}</p>
+  }
+
+  if (item?.type === 'list') {
+    return (
+      <ul key={idx}>
+        {item.items.map((listItem, listIdx) => (
+          <li key={listIdx}>{listItem}</li>
+        ))}
+      </ul>
+    )
+  }
+
+  if (Array.isArray(item)) {
+    return item.map((subItem, subIdx) => renderContent(subItem, `${idx}-${subIdx}`))
+  }
+
+  return null
+}
+
 const Section = ({ title, content }) => {
   return (
     <div className="saannot-section">
       <h2>{title}</h2>
-      <div className="saannot-content">{content}</div>
+      <div className="saannot-content">
+        {Array.isArray(content)
+          ? content.map((item, idx) => renderContent(item, idx))
+          : content}
+      </div>
     </div>
   )
 }

--- a/algojkl-frontend/src/components/Typewriter.jsx
+++ b/algojkl-frontend/src/components/Typewriter.jsx
@@ -4,6 +4,7 @@ const Typewriter = ({ text = '', speed = 45 }) => {
   const [displayedText, setDisplayedText] = useState('')
 
   useEffect(() => {
+    setDisplayedText('')
     if (!text) return
     let index = 0
     const interval = setInterval(() => {

--- a/algojkl-frontend/src/components/kansainvalisyys/Kielitodistukset.jsx
+++ b/algojkl-frontend/src/components/kansainvalisyys/Kielitodistukset.jsx
@@ -1,13 +1,15 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import Section from '../../common/Section'
 
-const Kielitodistukset = () => (
-  <Section title="Kielitodistukset">
-    <p>
-      Monet vaihtokohteet saattavat vaatia kielitodistuksen. Kielitodistuksia
-      voi hankkia Movilta. Lisätietoja saa ottamalla yhteyttä Niina Ormashawiin.
-    </p>
-  </Section>
-)
+const Kielitodistukset = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <Section title={t('pages.kansainvalisyys.languageCertificates.title')}>
+      <p>{t('pages.kansainvalisyys.languageCertificates.body')}</p>
+    </Section>
+  )
+}
 
 export default Kielitodistukset

--- a/algojkl-frontend/src/components/kansainvalisyys/Sivustot.jsx
+++ b/algojkl-frontend/src/components/kansainvalisyys/Sivustot.jsx
@@ -1,35 +1,40 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import Section from '../../common/Section'
 
-const Sivustot = () => (
-  <Section title="Sivustot">
-    <ul>
-      <li>
-        <strong>Hakuprosessi Mobility Online -portaalissa:</strong>
-        <a href="https://www.service4mobility.com/europe/MobilitySearchServlet?sprache=en&identifier=JYVASKY01">
-          Mobility Online -portaali
-        </a>
-      </li>
-      <li>
-        <strong>Ohjeita hakuvaiheeseen:</strong>{' '}
-        <a href="https://www.jyu.fi/fi/opiskelijalle/.../vaihtoon-hakeminen">
-          Step by step -hakuohjeet
-        </a>
-      </li>
-      <li>
-        <strong>Valmistautuminen vaihtoon:</strong>{' '}
-        <a href="https://www.jyu.fi/fi/opiskelijalle/.../ennen-vaihtoa">
-          Valmistautumisohjeet
-        </a>
-      </li>
-      <li>
-        <strong>Vaihdon rahoitus:</strong>{' '}
-        <a href="https://www.jyu.fi/fi/opiskelijalle/.../opiskelijavaihdon-rahoitus">
-          Vaihdon rahoitus
-        </a>
-      </li>
-    </ul>
-  </Section>
-)
+const Sivustot = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <Section title={t('pages.kansainvalisyys.sites.title')}>
+      <ul>
+        <li>
+          <strong>{t('pages.kansainvalisyys.sites.mobilityLabel')}</strong>
+          <a href="https://www.service4mobility.com/europe/MobilitySearchServlet?sprache=en&identifier=JYVASKY01">
+            {t('pages.kansainvalisyys.sites.mobilityLink')}
+          </a>
+        </li>
+        <li>
+          <strong>{t('pages.kansainvalisyys.sites.applicationLabel')}</strong>{' '}
+          <a href="https://www.jyu.fi/fi/opiskelijalle/.../vaihtoon-hakeminen">
+            {t('pages.kansainvalisyys.sites.applicationLink')}
+          </a>
+        </li>
+        <li>
+          <strong>{t('pages.kansainvalisyys.sites.preparationLabel')}</strong>{' '}
+          <a href="https://www.jyu.fi/fi/opiskelijalle/.../ennen-vaihtoa">
+            {t('pages.kansainvalisyys.sites.preparationLink')}
+          </a>
+        </li>
+        <li>
+          <strong>{t('pages.kansainvalisyys.sites.fundingLabel')}</strong>{' '}
+          <a href="https://www.jyu.fi/fi/opiskelijalle/.../opiskelijavaihdon-rahoitus">
+            {t('pages.kansainvalisyys.sites.fundingLink')}
+          </a>
+        </li>
+      </ul>
+    </Section>
+  )
+}
 
 export default Sivustot

--- a/algojkl-frontend/src/components/kansainvalisyys/VaihtoOhjelmat.jsx
+++ b/algojkl-frontend/src/components/kansainvalisyys/VaihtoOhjelmat.jsx
@@ -1,43 +1,43 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import Section from '../../common/Section'
 
-const VaihtoOhjelmat = () => (
-  <Section title="Vaihto-ohjelmat">
-    <ul>
-      <li>
-        <strong>Erasmus (Eurooppa)</strong>
-        <p>
-          Erasmus tarjoaa 1–2 lukukauden vaihdon EU- ja ETA-maissa sekä
-          Turkissa.
-        </p>
-        <ul>
-          <li>
-            <a href="https://www.jyu.fi/fi/opiskelijalle/.../erasmus">
-              Erasmus-ohjelma
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <strong>Kahdenväliset kohteet</strong>
-        <p>Vaihdot Euroopan ulkopuolelle kuten Amerikkaan ja Aasiaan.</p>
-      </li>
-      <li>
-        <strong>ISEP</strong>
-        <p>Yksi hakemus useisiin yliopistoihin ympäri maailmaa.</p>
-      </li>
-      <li>
-        <strong>Nordplus</strong>
-        <p>Mahdollistaa vaihdon Pohjoismaihin ja Baltiaan.</p>
-      </li>
-      <li>
-        <strong>FORTHEM</strong>
-        <p>
-          Tarjoaa lyhytliikkuvuuksia ja Erasmus-vaihtoja allianssin sisällä.
-        </p>
-      </li>
-    </ul>
-  </Section>
-)
+const VaihtoOhjelmat = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <Section title={t('pages.international.title')}>
+      <ul>
+        <li>
+          <strong>{t('pages.international.erasmusName')}</strong>
+          <p>{t('pages.international.erasmusDescription')}</p>
+          <ul>
+            <li>
+              <a href="https://www.jyu.fi/fi/opiskelijalle/.../erasmus">
+                {t('pages.international.erasmusLink')}
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <strong>{t('pages.international.bilateralName')}</strong>
+          <p>{t('pages.international.bilateralDescription')}</p>
+        </li>
+        <li>
+          <strong>{t('pages.international.isepName')}</strong>
+          <p>{t('pages.international.isepDescription')}</p>
+        </li>
+        <li>
+          <strong>{t('pages.international.northName')}</strong>
+          <p>{t('pages.international.northDescription')}</p>
+        </li>
+        <li>
+          <strong>{t('pages.international.forthemName')}</strong>
+          <p>{t('pages.international.forthemDescription')}</p>
+        </li>
+      </ul>
+    </Section>
+  )
+}
 
 export default VaihtoOhjelmat

--- a/algojkl-frontend/src/components/kansainvalisyys/Vaihtovinkit.jsx
+++ b/algojkl-frontend/src/components/kansainvalisyys/Vaihtovinkit.jsx
@@ -1,37 +1,36 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import Section from '../../common/Section'
 
-const Vaihtovinkit = () => (
-  <Section title="Vaihtovinkit">
-    <ul>
-      <li>
-        <strong>Opintopistevaatimukset:</strong> Suorita yleensä vähintään 20 op
-        per lukukausi.
-      </li>
-      <li>
-        <strong>Kurssisuunnitelma:</strong> Tee Learning Agreement ja hyväksytä
-        se molemmissa yliopistoissa.
-        <ul>
-          <li>Suunnitelma on alustava ja sitä voi muuttaa vaihdon aikana.</li>
-          <li>Kurssit voivat muuttua ilmoittautumisen yhteydessä.</li>
-        </ul>
-      </li>
-      <li>
-        <strong>Opintotasojen huomioiminen:</strong>
-        <ul>
-          <li>Valitse kurssitaso (kandi/maisteri) tavoitteidesi mukaan.</li>
-          <li>
-            Kandikurssit usein paikallisella kielellä, maisterikurssit
-            englanniksi.
-          </li>
-          <li>
-            Joissain tapauksissa tarvitaan todistus oikeudesta suorittaa
-            maisteritason opintoja.
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </Section>
-)
+const Vaihtovinkit = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <Section title={t('pages.kansainvalisyys.tips.title')}>
+      <ul>
+        <li>
+          <strong>{t('pages.kansainvalisyys.tips.creditsLabel')}</strong>{' '}
+          {t('pages.kansainvalisyys.tips.creditsText')}
+        </li>
+        <li>
+          <strong>{t('pages.kansainvalisyys.tips.studyPlanLabel')}</strong>{' '}
+          {t('pages.kansainvalisyys.tips.studyPlanText')}
+          <ul>
+            <li>{t('pages.kansainvalisyys.tips.studyPlanPoint1')}</li>
+            <li>{t('pages.kansainvalisyys.tips.studyPlanPoint2')}</li>
+          </ul>
+        </li>
+        <li>
+          <strong>{t('pages.kansainvalisyys.tips.levelLabel')}</strong>
+          <ul>
+            <li>{t('pages.kansainvalisyys.tips.levelPoint1')}</li>
+            <li>{t('pages.kansainvalisyys.tips.levelPoint2')}</li>
+            <li>{t('pages.kansainvalisyys.tips.levelPoint3')}</li>
+          </ul>
+        </li>
+      </ul>
+    </Section>
+  )
+}
 
 export default Vaihtovinkit

--- a/algojkl-frontend/src/components/kansainvalisyys/Vaihtovuosi.jsx
+++ b/algojkl-frontend/src/components/kansainvalisyys/Vaihtovuosi.jsx
@@ -1,74 +1,52 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import Section from '../../common/Section'
 
-const Vaihtovuosi = () => (
-  <>
-    <h2>Vaihtoon lähtemisen vuosikello</h2>
+const Vaihtovuosi = () => {
+  const { t } = useTranslation('common')
 
-    <Section title="Tammikuu">
-      <p>
-        Infotilaisuuksia järjestetään yleensä tammikuun puolivälin jälkeen,
-        jolloin saat kattavan kuvan vaihto-ohjelmista ja -mahdollisuuksista.
-      </p>
-      <ul>
-        <li>
-          <strong>Tammikuussa alkavat haut:</strong>
-          <ul>
-            <li>
-              <strong>22.1. – 5.2.</strong> Haku Euroopan vaihtokohteisiin
-              (Erasmus, Nordplus, Nordlys).
-            </li>
-            <li>
-              <strong>22.1. – 5.2.</strong> Lisähaku Euroopan ulkopuolisiin
-              kohteisiin.
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </Section>
+  return (
+    <>
+      <h2>{t('pages.kansainvalisyys.yearClockTitle')}</h2>
 
-    <Section title="Helmi- ja Maaliskuu">
-      <p>
-        Näiden kuukausien aikana ei ole varsinaisia hakuaikoja, mutta voit
-        käyttää aikaa hakemuksen valmisteluun ja vaihtokohteen suunnitteluun.
-      </p>
-    </Section>
+      <Section title={t('pages.kansainvalisyys.months.january.title')}>
+        <p>{t('pages.kansainvalisyys.months.january.intro')}</p>
+        <ul>
+          <li>
+            <strong>{t('pages.kansainvalisyys.months.january.searches')}</strong>
+            <ul>
+              <li>{t('pages.kansainvalisyys.months.january.search1')}</li>
+              <li>{t('pages.kansainvalisyys.months.january.search2')}</li>
+            </ul>
+          </li>
+        </ul>
+      </Section>
 
-    <Section title="Huhtikuu">
-      <p>
-        <strong>1.4. – 31.5.</strong> Täydennyshaku Erasmus-opiskelijavaihtoon.
-        Hakemuksia käsitellään juoksevasti koko hakuajan ajan.
-      </p>
-    </Section>
+      <Section title={t('pages.kansainvalisyys.months.febMarch.title')}>
+        <p>{t('pages.kansainvalisyys.months.febMarch.body')}</p>
+      </Section>
 
-    <Section title="Syyskuu">
-      <p>
-        <strong>2.9. – 30.9</strong> Täydennyshaku Erasmus- ja Nordplus-vaihtoon
-        kevätlukukaudeksi 2025.
-      </p>
-    </Section>
+      <Section title={t('pages.kansainvalisyys.months.april.title')}>
+        <p>{t('pages.kansainvalisyys.months.april.body')}</p>
+      </Section>
 
-    <Section title="Lokakuu">
-      <p>
-        <strong>1.10. – 1.11.</strong> Haku Euroopan ulkopuolisiin
-        vaihtokohteisiin, mukaan lukien ISEP-vaihto.
-      </p>
-    </Section>
+      <Section title={t('pages.kansainvalisyys.months.september.title')}>
+        <p>{t('pages.kansainvalisyys.months.september.body')}</p>
+      </Section>
 
-    <Section title="Touko- ja joulukuu">
-      <p>
-        Hae matka-apurahaa, jos olet löytänyt harjoittelupaikan ulkomailta.
-        Hakuajat vaihtelevat vuosittain.
-      </p>
-    </Section>
+      <Section title={t('pages.kansainvalisyys.months.october.title')}>
+        <p>{t('pages.kansainvalisyys.months.october.body')}</p>
+      </Section>
 
-    <Section title="Ympäri vuoden">
-      <p>
-        Erasmus-harjoitteluapuraha on haettavissa koko vuoden ajan. Huomioi
-        kuitenkin käsittelyajat.
-      </p>
-    </Section>
-  </>
-)
+      <Section title={t('pages.kansainvalisyys.months.mayDecember.title')}>
+        <p>{t('pages.kansainvalisyys.months.mayDecember.body')}</p>
+      </Section>
+
+      <Section title={t('pages.kansainvalisyys.months.allYear.title')}>
+        <p>{t('pages.kansainvalisyys.months.allYear.body')}</p>
+      </Section>
+    </>
+  )
+}
 
 export default Vaihtovuosi

--- a/algojkl-frontend/src/components/ohjesäännöt/Haalarietiketti.jsx
+++ b/algojkl-frontend/src/components/ohjesäännöt/Haalarietiketti.jsx
@@ -1,31 +1,23 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 const Haalarietiketti = () => {
+  const { t } = useTranslation('common')
+  const paragraphs = t('pages.ohjesaannot.haalarietiketti.paragraphs', {
+    returnObjects: true,
+  })
+
   return (
     <div>
-      <h1>Haalarietiketti</h1>
+      <h1>{t('pages.ohjesaannot.haalarietiketti.title')}</h1>
       <p>
-        <strong>1. Haalareiden käyttö</strong>
-        <br />
-        Haalareita suositellaan pidettävän ylhäällä eli kokonaan päällä. Niitä
-        käytetään kaikissa opiskelijatapahtumissa, ellei tapahtuman
-        pukeutumisesta erikseen toisin mainita. Kun haalareita pidetään
-        vyötäröllä, selkäosa taitetaan siten, että killan logo näkyy. Haalareita
-        saa ja tulee muokata oman näköisiksi.
-        <br />
-        <br />
-        <strong>2. Haalarimerkit</strong>
-        <br />
-        Haalarimerkit tulee ommella käsin. Niitä ei saa liimata eikä ommella
-        ompelukoneella. Lisäksi haalarimerkkejä ei tule ommella sponsoreiden
-        logojen päälle, mikäli tilaa on.
-        <br />
-        <br />
-        <strong>3. Haalarien pesu</strong>
-        <br />
-        Haalareita ei saa pestä pesukoneessa tai muulla vastaavalla tavoin.
-        Haalarit pestään siten, että olet itse niiden sisällä, esimerkiksi
-        järvessä tai suihkussa.
+        {paragraphs.map((paragraph, idx) => (
+          <span key={idx}>
+            {paragraph}
+            <br />
+            <br />
+          </span>
+        ))}
       </p>
     </div>
   )

--- a/algojkl-frontend/src/components/ohjesäännöt/JuhlanauhaMerkit.jsx
+++ b/algojkl-frontend/src/components/ohjesäännöt/JuhlanauhaMerkit.jsx
@@ -1,103 +1,22 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 const JuhlanauhaMerkit = () => {
+  const { t } = useTranslation('common')
+  const rules = t('pages.ohjesaannot.rules', { returnObjects: true })
+
   return (
     <div>
+      <p>{t('pages.ohjesaannot.intro')}</p>
+      <h1>{t('pages.ohjesaannot.title')}</h1>
       <p>
-        Tältä sivulta löydät tietoa teekkarilakista, haalarietiketistä sekä
-        juhlanauha- ja merkkiohjesäännöstä.
-      </p>
-      <h1>Juhlanauha- ja merkkiohjesääntö</h1>
-      <p>
-        1§ Algo ry:llä on kunnia-, ansio-, hallitus- ja vuoden algolainen
-        -merkki sekä juhlanauha, joista jäljempänä lähemmin määrätään. Merkkien
-        mallikappaleet säilytetään yhdistyksen arkistossa, ja myönnetyistä sekä
-        ohjesäännön mukaan jaetuista merkeistä, niiden myöntämisperusteista ja
-        päivämääristä pidetään luetteloa.
-        <br />
-        <br />
-        2§ Merkkien antamisesta päättää yhdistyksen hallitus. Hallitus voi jakaa
-        useamman merkin kuin mitä tämän ohjesäännön enimmäismäärä sallii, mikäli
-        hallitus päättää siitä yksimielisesti. Ellei päätösehdotusta hyväksytä,
-        ei asian käsittelystä tehdä merkintää pöytäkirjaan.
-        <br />
-        <br />
-        3§ Kunniajäsenekseen yhdistys voi hallituksen esityksestä kutsua
-        yhdistyksen toimintaa ansiokkaasti tukeneen henkilön, joka on antanut
-        siihen suostumuksensa. Kunniajäsenelle myönnetään kunniakirja, joka on
-        varustettu istuvan puheenjohtajan nimikirjoituksella, ja hänet kutsutaan
-        yhdistyksen vuosijuhliin joka vuosi, mikäli sellaiset järjestetään.
-        Kunniajäsenyys on elinikäinen.
-        <br />
-        <br />
-        4§ Kunniamerkki voidaan antaa henkilölle, joka pitkäaikaisella
-        toiminnallaan tai erittäin merkittävällä teollaan on huomattavasti
-        edistänyt yhdistyksen toimintaa. Kunniamerkki myönnetään myös jokaiselle
-        kunniajäsenelle joko kunniajäseneksi myöntämisen yhteydessä tai
-        takautuvasti. Kunniamerkkejä voidaan vuosittain myöntää enintään kolme
-        (3) kappaletta. Kunniamerkki on väriltään kultainen ja kooltaan xx mm.
-        <br />
-        <br />
-        5§ Ansiomerkki voidaan antaa henkilölle, joka on viimeisen vuoden aikana
-        edistänyt ansiokkaasti yhdistyksen toimintaa. Ansiomerkkejä voidaan
-        vuosittain myöntää enintään viisi (5) kappaletta. Ansiomerkki on
-        väriltään hopeinen ja kooltaan xx mm.
-        <br />
-        <br />
-        6§ Hallitusmerkki myönnetään yhdistyksen istuvan hallituksen jäsenille.
-        Hallitusmerkki voidaan myöntää myös yhdistyksen hallituksen entiselle
-        jäsenelle. Hallitusmerkki on väriltään hopeinen ja kooltaan 16 mm.
-        <br />
-        <br />
-        7§ Vuoden algolainen -merkki myönnetään Algo ry:n jäsenelle, joka on
-        osoittanut merkittävää kiinnostusta yhdistyksen toimintaa kohtaan ja
-        edistänyt jäsenten välistä yhteishenkeä. Jäsen valitaan vuosittain
-        järjestettävällä äänestyksellä, jossa jokaisella Algo ry:n jäsenellä on
-        äänioikeus. Äänestyksestä tiedotetaan yhdistyksen virallisilla
-        viestintäkanavilla viimeistään 2 viikkoa ennen merkinjakotilaisuutta.
-        Yksittäinen henkilö voi saada merkin vain kerran. Vuoden algolainen
-        -merkki on haalarimerkki, joka on halkaisijaltaan 80 mm ja väriltään
-        violetti keltaisella pokaalilla.
-        <br />
-        <br />
-        8§ Myönnetyt merkit ja kunniakirjat luovutetaan saajilleen seuraavissa
-        yhdistyksen vuosijuhlissa, vuosijuhlasitseillä tai muussa hallituksen
-        sopivaksi katsomassa arvokkaassa tilaisuudessa. Kaikkien Algo ry:n
-        myöntämien merkkien käyttöoikeus on elinikäinen.
-        <br />
-        <br />
-        9§ Juhlanauha on 35 mm leveä ja väriltään vaaleapuna-valkoinen.
-        Jokaisella yhdistyksen varsinaisella jäsenellä on nauhan käyttöoikeus,
-        ja nauhan voi ostaa suoraan yhdistykseltä. Juhlanauha myönnetään
-        ansiomerkin mukana ilmaiseksi, mikäli ansioituvalla henkilöllä ei
-        sellaista vielä ole. Juhlanauhan käyttöoikeus säilyy yhdistyksestä
-        eroamisen jälkeen.
-        <br />
-        <br />
-        10§ Juhlanauhaa sekä kunnia-, ansio- ja hallitusmerkkiä käytetään vain
-        juhlapuvussa akateemisissa juhlatilaisuuksissa.
-        <br />
-        <br />
-        Juhlanauhaa kannetaan siten, että se kulkee oikealta olkapäältä rinnan
-        yli vasemmalle lantiolle, vaaleanpunainen väri yläpuolella. Juhlanauhaa
-        kannetaan juhlapuvussa liivin alla ja tummassa puvussa liivin ja solmion
-        päällä. Mekon kanssa juhlanauhaa voi kantaa taiteltuna ruusukkeena
-        vasemmalla puolella rintaa, vaaleanpunainen väri päällimmäisenä, tai
-        kuten juhlapuvussa. Juhlanauha ei saa koskettaa paljasta ihoa.
-        <br />
-        <br />
-        Algo ry:n omissa tilaisuuksissa juhlanauhaa kannetaan ylimpänä, jos
-        kantajalla on myös muiden organisaatioiden nauhoja. Muissa
-        tilaisuuksissa noudatetaan soveltuvia ohjesääntöjä.
-        <br />
-        <br />
-        Kunnia-, ansio- ja hallitusmerkkejä voi käyttää samanaikaisesti
-        juhlanauhan kanssa, eikä niiden asettelulla ole väliä.
-        <br />
-        <br />
-        11§ Tämä ohjesääntö on hyväksytty yhdistyksen kokouksessa 26.5.2023. Se
-        on voimassa toistaiseksi. Tämän ohjesäännön muuttamisesta päättää
-        yhdistyksen kokous ehdottomalla äänienemmistöllä.
+        {rules.map((rule, idx) => (
+          <span key={idx}>
+            {rule}
+            <br />
+            <br />
+          </span>
+        ))}
       </p>
     </div>
   )

--- a/algojkl-frontend/src/components/ohjesäännöt/Teekkari.jsx
+++ b/algojkl-frontend/src/components/ohjesäännöt/Teekkari.jsx
@@ -1,30 +1,24 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import lakki from '../../images/lakki.jpg'
 
 export const Teekkari = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <img
         src={lakki}
-        alt="Jyväskylän 8-kulmainen teekkarilakki"
+        alt={t('pages.ohjesaannot.teekkari.imageAlt')}
         className="lakki"
       />
-      <h1>Teekkarilakki</h1>
+      <h1>{t('pages.ohjesaannot.teekkari.title')}</h1>
       <p>
-        Jyväskylän teekkarilakki on kahdeksankulmainen, Jyväskylän kävelykadun
-        Kompassin muodon mukaan. Lakin sisäpuoli on Jyväskylän yliopiston värien
-        mukainen sini-oranssi. Lakin kokardissa yhdistyy Jyväskylä sekä
-        tekniikka, kun kokardista löytyy JYY:n soihtu, jota ympäröi tekniikan
-        ratas.
+        {t('pages.ohjesaannot.teekkari.description')}
         <br />
         <br />
-        Ensimmäisen vuoden diplomi-insinööriopiskelijoista eli fukseista tulee
-        teekkareita vappuna, jolloin kasteen jälkeen lakin saa painaa päähänsä.
-        Lakin kantoaika alkaa siis vapun kasteesta ja päättyy syyskuun
-        viimeisenä päivänä pidettäviin lakinlaskijaisiin.
-        <br />
-        <br />
-        <a href="https://jytyjkl.fi/">Jyväskylän teekkariyhdistys</a> hallinnoi Jyväskylässä teekkarilakkia koskevia lakinkäyttösääntöjä. Jyväskylän teekkariyhdistyksen kautta voidaan hakea <a href="https://jytyjkl.fi/lakkiohjesaanto">lakinkäyttölupaa</a> lakinkantoajan ulkopuolella.
+        <a href="https://jytyjkl.fi/">{t('pages.ohjesaannot.teekkari.linkText')}</a>{' '}
+        {t('pages.ohjesaannot.teekkari.linkText2')}
       </p>
     </div>
   )

--- a/algojkl-frontend/src/components/periaatteet/TTPeriaatteet.jsx
+++ b/algojkl-frontend/src/components/periaatteet/TTPeriaatteet.jsx
@@ -1,51 +1,29 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 const TurvallisemmanTilanPeriaatteet = () => {
+  const { t } = useTranslation('common')
+  const values = t('pages.periaatteet.values', { returnObjects: true })
+  const safety = t('pages.periaatteet.safety', { returnObjects: true })
+
   return (
     <div>
       <h3>
-        <strong>
-          Algo ja sen jäsenet sitoutuvat noudattamaan seuraavia arvoja:
-        </strong>
+        <strong>{t('pages.periaatteet.valuesTitle')}</strong>
       </h3>
       <ul>
-        <li>
-          Kaikki ihmiset ovat samanarvoisia riippumatta heidän sukupuolestaan,
-          iästään, etnisestä tai kansallisesta alkuperästään,
-          kansalaisuudestaan, kielestään, uskonnostaan, seksuaalisesta
-          suuntautumisestaan tai muusta henkilöön liittyvästä syystä
-        </li>
-        <li>Ei painostateta päihteiden käyttöön.</li>
-        <li>Noudatetaan hyviä käytöstapoja ja käyttäydytään asiallisesti.</li>
-        <li>Ymmärretään ja kunnioitetaan erilaisia näkökulmia.</li>
-        <li>Ylläpidetään, luodaan ja kehitetään tervettä Teekkarihenkeä.</li>
-        <li>
-          Jokainen nauttii opiskeluajastansa omilla ehdoillaan sekä edellä
-          mainittujen periaatteiden ja Suomen lakien mukaisesti.
-        </li>
-        <li>Noudatetaan turvallisen tilan periaatteita (alla).</li>
+        {values.map((value, idx) => (
+          <li key={idx}>{value}</li>
+        ))}
       </ul>
 
       <h3>
-        <strong>Algo ry:n turvallisemman tilan periaatteet:</strong>
+        <strong>{t('pages.periaatteet.safetyTitle')}</strong>
       </h3>
       <ul>
-        <li>Lopeta häiritsevä käytös ja pyydä välittömästi anteeksi.</li>
-        <li>
-          Huolehdi, että kaikki pääsevät halutessaan osalliseksi ja tulevat
-          kuulluiksi.
-        </li>
-        <li>
-          Älä häiritse ketään sanallisesti, koskettamalla tai tuijottamalla.
-        </li>
-        <li>
-          Jokainen saa osallistua ja jakaa asioita haluamassaan laajuudessa.
-        </li>
-        <li>Anna tilaa ja käsittele arkoja asioita kunnioittavasti.</li>
-        <li>Älä tee oletuksia ihmisten ulkoisista ominaisuuksista.</li>
-        <li>Vältä syrjiviä stereotypioita puheessasi ja toiminnassasi.</li>
-        <li>Kunnioita henkilökohtaista tilaa ja muiden rajoja.</li>
-        <li>Puutumme asiattomaan ja häiritsevään käytökseen.</li>
+        {safety.map((item, idx) => (
+          <li key={idx}>{item}</li>
+        ))}
       </ul>
     </div>
   )

--- a/algojkl-frontend/src/components/periaatteet/ToimintaInfo.jsx
+++ b/algojkl-frontend/src/components/periaatteet/ToimintaInfo.jsx
@@ -1,24 +1,24 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 const ToimintaInfo = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
-      <h1>Toiminnasta</h1>
+      <h1>{t('pages.periaatteet.title')}</h1>
       <p>
-        Algon killan sisällä apua voi hakea sopolta/kopolta (sopo@algojkl.com &
-        kopo@algojkl.com) tai anonyymisti lomakkeella, jonka löydät{' '}
+        {t('pages.periaatteet.intro')}{' '}
         <strong>
-          <a href="https://forms.gle/zEB8omZsu8MbgTK38">täältä</a>
+          <a href="https://forms.gle/zEB8omZsu8MbgTK38">
+            {t('pages.periaatteet.formLink')}
+          </a>
         </strong>
-        . Lomakkeen vastaukset näkyvät vain sopolle/kopolle.
+        . {t('pages.periaatteet.support')}
       </p>
       <p>
-        <strong>Toiminnasta:</strong> <br />
-        Algo ei hyväksy minkäänlaista syrjintää tai häirintää omassa
-        toiminnassaan ja pyrimme rakentamaan kannustavaa ilmapiiriä. Jos kohtaat
-        väärinkäytöksiä, häirintää, syrjintää tai koet olosi turvattomaksi,
-        kerro asiasta ja pyydä apua. Tukea ja apua on aina saatavilla jos koet
-        sitä tarvitsevasi.
+        <strong>{t('pages.periaatteet.summaryTitle')}</strong> <br />
+        {t('pages.periaatteet.summary')}
       </p>
     </div>
   )

--- a/algojkl-frontend/src/components/periaatteet/Yhdenvertaisuus.jsx
+++ b/algojkl-frontend/src/components/periaatteet/Yhdenvertaisuus.jsx
@@ -1,32 +1,15 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 const Yhdenvertaisuus = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <h3>
-        <strong>Yhdenvertaisuus:</strong>
+        <strong>{t('pages.periaatteet.equalityTitle')}</strong>
       </h3>
-      <p>
-        Algo pyrkii luomaan jäsenilleen mahdollisimman turvallisen, luotettavan
-        sekä yhdenvertaisen ympäristön jokaiselle jäsenelleen.
-        <br />
-        <br />
-        Yliopistolakiin on kirjattu, että yliopiston tulee tarjota turvallinen
-        opiskeluympäristö, jossa jokaisella on oikeus opiskella kokematta
-        häirintää, kiusaamista ja syrjintää (Yliopistolaki 41§). Algo ry ei
-        suvaitse tapahtumissaan kiusaamista, syrjimistä, häirintää tai muuta
-        epäasiallista käytöstä missään muodossa. Haluamme olla edistämässä
-        kaikille turvallista ja viihtyisää korkeakouluyhteisöä. Kiusaamiselta
-        tai häirinnältä ei aina voi välttyä. Täten on ehdottoman tärkeää
-        reagoida kiusaamistilanteisiin.
-        <br />
-        <br />
-        Jyväskylän yliopistossa voit hakea apua esimerkiksi Hyviksiltä, jotka
-        tarjoavat keskusteluapua ja ohjaavat tarvittaessa eteenpäin. Apua
-        tarjoavat myös JYY:n häirintäyhteyshenkilöt tai sopo. Kaikki jaettu
-        tieto on luottamuksellista, eikä siitä puhuta kenellekään ilman
-        asianomaisen lupaa.
-      </p>
+      <p>{t('pages.periaatteet.equality')}</p>
     </div>
   )
 }

--- a/algojkl-frontend/src/components/perustajat.jsx
+++ b/algojkl-frontend/src/components/perustajat.jsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 const Perustajat = ({ image, members, year }) => {
+  const { t } = useTranslation('common')
+
   return (
     <div className="kunnia-container">
-      <h2>Perustajajäsenet & Hallitus {year}</h2>
+      <h3>{t('pages.perustajat.title', { year })}</h3>
       <div className="perustaja-flex">
         <img src={image} alt="hallitus" width={250} />
         <ul className="perustaja">

--- a/algojkl-frontend/src/components/toimari/Toimari.jsx
+++ b/algojkl-frontend/src/components/toimari/Toimari.jsx
@@ -1,19 +1,23 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 function Toimari({ member }) {
+  const { t } = useTranslation('common')
+
   return (
     <div className="toimari-card">
       <div className="toimari-image">
         {member.kuva ? (
           <img src={member.kuva} alt={member.nimi} />
         ) : (
-          <div className="placeholder-image">Ei kuvaa</div>
+          <div className="placeholder-image">{t('pages.toimari.noImage')}</div>
         )}
       </div>
       <div className="toimari-info">
         <h3>{member.nimi}</h3>
         <p>{member.pesti}</p>
-        <p>Telegram: {member.telegram}</p>
+        <p>{member.email}</p>
+        <p>{t('pages.hallitus.telegram')} {member.telegram}</p>
       </div>
     </div>
   )

--- a/algojkl-frontend/src/components/yhteydenotto/Kurssipalaute.jsx
+++ b/algojkl-frontend/src/components/yhteydenotto/Kurssipalaute.jsx
@@ -1,29 +1,26 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
 import YhteydenottoSection from './YhteydenottoSection'
 
-const Kurssipalaute = () => (
-  <YhteydenottoSection title="Kurssipalaute">
-    <p>
-      Algo ry:n yksi tärkeimpiä tehtäviä on edunvalvonta ja kilta pyrkii
-      vaikuttamaan opetuksen kehittämiseen. Tällä lomakkeella voit antaa
-      palautetta tietystä kurssista liittyen opetukseen, arviointiin tai mihin
-      vaan.{' '}
-      <strong>
-        Tämä palaute ei korvaa yliopiston virallista tai opettajan antamaa
-        kurssipalautelomaketta!
-      </strong>
-    </p>
+const Kurssipalaute = () => {
+  const { t } = useTranslation('common')
 
-    <p>
-      Tätä palautetta kerää ja käyttää Algon kopo ja puheenjohtaja. Tämän
-      palautteen voit antaa täysin anonyymisti tai antaa yhteystietosi jos
-      haluat että sinuun ollaan yhteydessä. Palautteet viedään kuitenkin
-      eteenpäin täysin anonyymeinä.
-    </p>
-    <p>
-      Linkki lomakkeeseen:{' '}
-      <a href="https://forms.gle/eXQokL9ukeJNgKoAA">Kurssipalautelomake</a>
-    </p>
-  </YhteydenottoSection>
-)
+  return (
+    <YhteydenottoSection title={t('pages.yhteydenotto.course.title')}>
+      <p>
+        {t('pages.yhteydenotto.course.description')}{' '}
+        <strong>{t('pages.yhteydenotto.course.warning')}</strong>
+      </p>
+
+      <p>{t('pages.yhteydenotto.course.description2')}</p>
+      <p>
+        {t('pages.yhteydenotto.course.linkPrefix')}{' '}
+        <a href="https://forms.gle/eXQokL9ukeJNgKoAA">
+          {t('pages.yhteydenotto.course.linkLabel')}
+        </a>
+      </p>
+    </YhteydenottoSection>
+  )
+}
 
 export default Kurssipalaute

--- a/algojkl-frontend/src/components/yhteydenotto/SopoKopo.jsx
+++ b/algojkl-frontend/src/components/yhteydenotto/SopoKopo.jsx
@@ -1,21 +1,20 @@
+import { useTranslation } from 'react-i18next'
 import YhteydenottoSection from './YhteydenottoSection'
 
-const SopoKopo = () => (
-  <YhteydenottoSection title="Sopo-Kopo Yhteydenottolomake">
-    <p>
-      Tällä lomakkeella voit ottaa yhteyttä jos olet kokenut asiatonta käytöstä,
-      väärinkäytöksiä opetuksessa tai haluat muuten vain kertoa ongelmistasi.
-      Voit halutessasi jättää yhteystietosi jos haluat että Algon
-      hyvinvointivastaava/sopo/kopo on sinuun asian tiimoilta yhteydessä.
-      Muutoin vastaukset tähän lomakkeeseen käsitellään luottamuksellisesti ja
-      anonyymisti. Vaikka jättäisit yhteystietosi, asiasi käsitellään
-      anonyymisti. Vain sopo/kopo näkee yhteystietosi.
-    </p>
-    <p>
-      Linkki lomakkeeseen:{' '}
-      <a href="https://forms.gle/5vLF7HQQosCeov5s8">SopoKopoLomake</a>
-    </p>
-  </YhteydenottoSection>
-)
+const SopoKopo = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <YhteydenottoSection title={t('pages.sopokopo.title')} headingLevel="h3">
+      <p>{t('pages.sopokopo.description')}</p>
+      <p>
+        {t('pages.sopokopo.formLinkLabel')}{' '}
+        <a href="https://forms.gle/5vLF7HQQosCeov5s8">
+          {t('pages.sopokopo.formLinkText')}
+        </a>
+      </p>
+    </YhteydenottoSection>
+  )
+}
 
 export default SopoKopo

--- a/algojkl-frontend/src/components/yhteydenotto/YhteydenottoSection.jsx
+++ b/algojkl-frontend/src/components/yhteydenotto/YhteydenottoSection.jsx
@@ -1,4 +1,6 @@
-const YhteydenottoSection = ({ title, children }) => {
+const YhteydenottoSection = ({ title, children, headingLevel = 'h2' }) => {
+  const HeadingTag = headingLevel
+
   return (
     <section className="yhteydenotto-container">
       <h1>{title}</h1>

--- a/algojkl-frontend/src/components/yhteydenotto/YleinenPalaute.jsx
+++ b/algojkl-frontend/src/components/yhteydenotto/YleinenPalaute.jsx
@@ -1,16 +1,20 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
 import YhteydenottoSection from './YhteydenottoSection'
 
-const YleinenPalaute = () => (
-  <YhteydenottoSection title="Yleinen palautelomake">
-    <p>
-      Tänne saat kertoa palautetta - niin positiivista kuin negatiivistakin.
-      Algon toiminnasta, nettisivuista tai mistä tahansa kiltaamme liittyvästä.
-    </p>
-    <p>
-      Linkki lomakkeeseen{' '}
-      <a href="https://forms.gle/fje29tPTM4PQCtws9">Palautelomake</a>
-    </p>
-  </YhteydenottoSection>
-)
+const YleinenPalaute = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <YhteydenottoSection title={t('pages.yhteydenotto.general.title')}>
+      <p>{t('pages.yhteydenotto.general.description')}</p>
+      <p>
+        <a href="https://forms.gle/fje29tPTM4PQCtws9">
+          {t('pages.yhteydenotto.general.linkLabel')}
+        </a>
+      </p>
+    </YhteydenottoSection>
+  )
+}
 
 export default YleinenPalaute

--- a/algojkl-frontend/src/locales/en/common.json
+++ b/algojkl-frontend/src/locales/en/common.json
@@ -1,0 +1,914 @@
+{
+  "nav": {
+    "brand": "Algo ry",
+    "menu": "GUILD",
+    "events": "EVENTS",
+    "collaboration": "COLLABORATION",
+    "fuksit": "FUKSIT",
+    "applicants": "APPLICANTS",
+    "sections": {
+      "staff": "STAFF MEMBERS",
+      "officialDocuments": "OFFICIAL DOCUMENTS",
+      "members": "FOR MEMBERS"
+    },
+    "links": {
+      "board": "BOARD",
+      "active": "ACTIVE MEMBERS",
+      "rules": "RULES",
+      "guidelines": "GUIDELINES & ETIQUETTE",
+      "vuju": "ANNUAL FESTIVITIES",
+      "privacy": "PRIVACY NOTICE",
+      "honours": "HALL OF FAME",
+      "principles": "OPERATING PRINCIPLES",
+      "benefits": "MEMBER BENEFITS",
+      "clubs": "CLUBS",
+      "recruitment": "RECRUITMENT",
+      "forms": "CONTACT FORMS",
+      "international": "INTERNATIONAL",
+      "kattila": "KATTILA COFFEE CAMERA",
+      "secrets": "SECRETS",
+      "songbook": "SONGBOOK",
+      "home": "HOME",
+      "documents": "DOCUMENTS",
+      "formsShort": "FORMS"
+    },
+    "language": {
+      "fi": "FI",
+      "en": "EN",
+      "toggle": "Choose language"
+    },
+    "joinButton": "JOIN AS A MEMBER"
+  },
+  "pages": {
+    "kansainvalisyys": {
+      "title": "Algo member exchange tips and links",
+      "alt": "International",
+      "yearClockTitle": "Exchange application timeline",
+      "months": {
+        "january": {
+          "title": "January",
+          "intro": "Information sessions are usually organised after mid-January, giving you a comprehensive overview of exchange programmes and opportunities.",
+          "searches": "Applications opening in January:",
+          "search1": "22 Jan – 5 Feb: Application period for European exchange destinations (Erasmus, Nordplus, Nordlys).",
+          "search2": "22 Jan – 5 Feb: Supplementary application period for destinations outside Europe."
+        },
+        "febMarch": {
+          "title": "February and March",
+          "body": "There are no main application periods during these months, but you can use the time to prepare your application and plan your destination."
+        },
+        "april": {
+          "title": "April",
+          "body": "1 Apr – 31 May: Supplementary application period for Erasmus student exchange. Applications are processed continuously throughout the application period."
+        },
+        "september": {
+          "title": "September",
+          "body": "2 Sept – 30 Sept: Supplementary application period for Erasmus and Nordplus exchanges for the spring term 2025."
+        },
+        "october": {
+          "title": "October",
+          "body": "1 Oct – 1 Nov: Application period for exchange destinations outside Europe, including ISEP exchange."
+        },
+        "mayDecember": {
+          "title": "May and December",
+          "body": "Apply for a travel grant if you have found an internship placement abroad. Application periods vary each year."
+        },
+        "allYear": {
+          "title": "Year-round",
+          "body": "The Erasmus internship grant can be applied for throughout the year. Please still note processing times."
+        }
+      },
+      "tips": {
+        "title": "Exchange tips",
+        "creditsLabel": "Credit requirements:",
+        "creditsText": "You should generally complete at least 20 ECTS credits per semester.",
+        "studyPlanLabel": "Course plan:",
+        "studyPlanText": "Prepare a Learning Agreement and have it approved by both universities.",
+        "studyPlanPoint1": "The plan is preliminary and can be changed during the exchange.",
+        "studyPlanPoint2": "Courses can change during enrolment.",
+        "levelLabel": "Considering course levels:",
+        "levelPoint1": "Choose course level (bachelor/master) according to your goals.",
+        "levelPoint2": "Bachelor-level courses are often in the local language, while master-level courses are often in English.",
+        "levelPoint3": "In some cases, you may need proof of your right to complete master's-level studies."
+      },
+      "sites": {
+        "title": "Useful sites",
+        "mobilityLabel": "Application process in the Mobility Online portal:",
+        "mobilityLink": "Mobility Online portal",
+        "applicationLabel": "Guidance for the application phase:",
+        "applicationLink": "Step-by-step application guide",
+        "preparationLabel": "Preparing for exchange:",
+        "preparationLink": "Preparation instructions",
+        "fundingLabel": "Exchange funding:",
+        "fundingLink": "Exchange funding"
+      },
+      "languageCertificates": {
+        "title": "Language certificates",
+        "body": "Many exchange destinations may require a language certificate. Certificates can be obtained from Movi. For more information, contact Niina Ormashawi."
+      }
+    },
+    "notFound": {
+      "title": "Page not found",
+      "description": "The page you requested does not exist. Check the address or return to the home page.",
+      "backHome": "Back to home"
+    },
+    "sopokopo": {
+      "title": "Sopo-Kopo contact form",
+      "description": "Use this form to reach out if you have experienced inappropriate conduct, misconduct in teaching, or simply want to report an issue. If you wish, you may leave your contact details so that Algo's wellbeing contact person / sopo-kopo can get back to you about the matter. Otherwise, the responses to this form are handled confidentially and anonymously. Even if you leave your contact information, your case will still be handled anonymously. Only the sopo-kopo will see your contact details.",
+      "formLinkLabel": "Form link:",
+      "formLinkText": "SopoKopo form"
+    },
+    "perustajat": {
+      "title": "Founding members & board {{year}}"
+    },
+    "personCard": {
+      "named": "Named {{year}}"
+    },
+    "eventCards": {
+      "showLess": "SHOW LESS",
+      "showLessAria": "Show fewer events",
+      "showMore": "SHOW MORE EVENTS",
+      "showMoreAria": "Show more events"
+    },
+    "eventModal": {
+      "tickets": "Tickets",
+      "dateLabel": "Date"
+    },
+    "fuksit": {
+      "alt": "Freshmen",
+      "title": "Hi there, new teekkari freshman!",
+      "subtitle": "Teekkari freshman* ~: cd /fuksisyksy",
+      "typewriter": "*A teekkari freshman is a person in their first year of studies, who after completing the teekkari initiation can call themselves a teekkari.",
+      "loading": "Loading...",
+      "error": "Error loading data!",
+      "beforeStudiesTitle": "Before studies start:",
+      "important": "The most important thing throughout your studies: keep an eye on your email!",
+      "studyStartTitle": "The start of studies",
+      "guildActivityTitle": "Guild activities",
+      "membershipTitle": "Membership",
+      "tutorTitle": "Tutors 2026 introduce themselves:",
+      "tutorNote": "Finnish-speaking tutors will introduce themselves in Finnish, and English-speaking tutors in English.",
+      "beforeStudies": [
+        {
+          "title": "Accept your study place",
+          "description": "Your study place must be accepted no later than 9.7.2026 at 15:00. You accept it through the Oma Opintopolku service."
+        },
+        {
+          "title": "Register as present and pay the student union membership fee",
+          "description": "Registration for the academic year as present takes place in the OILI registration service. At the same time, the student union membership fee is paid.",
+          "link": {
+            "href": "https://oili.csc.fi/",
+            "text": "OILI registration service"
+          }
+        },
+        {
+          "title": "Student health care fee",
+          "description": "Remember to pay the student health care fee. This fee is mandatory for every student, regardless of whether they use health care services or not.",
+          "link": {
+            "href": "https://www.kela.fi/korkeakouluopiskelijan-terveydenhoitomaksu",
+            "text": "More information"
+          }
+        },
+        {
+          "title": "Apply for housing",
+          "description": "Soihtu and Koas offer affordable student housing. It's worth applying broadly so that you can get housing more quickly. You can find more detailed instructions on the JYY website.",
+          "links": [
+            { "href": "https://soihtu.fi/", "text": "Soihtu" },
+            { "href": "https://www.koas.fi/fi/", "text": "Koas" }
+          ]
+        },
+        {
+          "title": "Apply for benefits from Kela",
+          "description": "Remember to apply for student and housing benefits from Kela.",
+          "link": {
+            "href": "https://www.kela.fi/opiskelijat-pikaopas",
+            "text": "Kela quick guide"
+          }
+        },
+        {
+          "title": "Order a student card",
+          "description": "With a student card, you get significant discounts on everyday services. For example, the price of student meals is 3.10€ with a student card (normally 9.00€). At the moment, Slice and Frank act as the student union's student cards. You can start using Slice at slice.fi/jyy and Frank at frank.fi/opiskelijakortti. More information about student cards is available on the JYY website.",
+          "links": [
+            { "href": "https://slice.fi/jyy", "text": "Slice" },
+            { "href": "https://frank.fi/opiskelijakortti", "text": "Frank" },
+            { "href": "https://jyy.fi/opiskelijalle/opiskelijakortti", "text": "JYY" }
+          ]
+        }
+      ],
+      "studyStart": [
+        "The orientation week for the information and software engineering and technology management programmes begins on 24 August 2026 at the University of Jyväskylä's Faculty of Information Technology in Agora."
+      ],
+      "guildActivity": [
+        "Algo ry is the guild for students of information and software engineering and technology management at the University of Jyväskylä. The guild's role is to protect the interests of its members, organise diverse events and cooperate with companies in the field. Above all, Algo is a community for its members throughout their studies."
+      ],
+      "membership": [
+        "Buy your Algo membership by pressing the \"Join as a Member\" button. Follow Algo on Instagram and TikTok. Join the Algo Discord too. Enjoy the benefits of Algo and have fun at upcoming events. Connecting to the Algo Telegram communication channels is possible through member newsletters sent by email or by asking board members."
+      ]
+    },
+    "hakijat": {
+      "alt": "Applicants",
+      "intro": "Great that you're interested in studying at the University of Jyväskylä! The University of Jyväskylä offers two different programmes for IT students:",
+      "degreeProgrammes": "Information and Software Engineering or Technology Management.",
+      "moreInfoIntro": "More information about the {{degree}} programme can be found on",
+      "moreInfoLink": "the University of Jyväskylä website.",
+      "aboutTitle": "What on earth is Algo ry?",
+      "aboutDescription": "Algo ry is the guild for students of information and software engineering and technology management at the University of Jyväskylä. The guild's role is to protect the interests of its members, organise diverse events and cooperate with companies in the field. Above all, Algo is a community for its members throughout their studies.",
+      "tutkinnot": [
+        {
+          "title": "Information and Software Engineering",
+          "ohjelmat": [
+            {
+              "name": "Bachelor of Engineering 180 ECTS",
+              "opinnot": [
+                "Basic and intermediate studies in information and software engineering 80 ECTS (incl. bachelor's thesis)",
+                "Basic mathematical studies in engineering 35 ECTS",
+                "A second study package (at least 25 ECTS) – the minor combines information technology with a field of your choice from the many options at the University of Jyväskylä. You can choose, for example, humanities such as psychology, sports and health sciences, culture and arts, or pedagogy. Alternatively, you can focus on mathematics or natural sciences.",
+                "Communication and language studies at least 10 ECTS",
+                "Freely selectable study packages, modules and other studies"
+              ]
+            },
+            {
+              "name": "Master of Science in Technology 120 ECTS",
+              "opinnot": [
+                "Advanced studies in information and software engineering 80 ECTS (incl. master's thesis)",
+                "A second study package (at least 25 ECTS) – the minor combines information technology with a field of your choice from the many options at the University of Jyväskylä. You can choose, for example, humanities such as psychology, sports and health sciences, culture and arts, or pedagogy. Alternatively, you can focus on mathematics or natural sciences.",
+                "Communication and language studies",
+                "Freely selectable study packages, modules and other studies"
+              ]
+            }
+          ],
+          "link": "https://www.jyu.fi/fi/tule-opiskelemaan/tutustu-aloihimme/tekniikka/tieto-ja-ohjelmistotekniikan-opinnot"
+        },
+        {
+          "title": "Technology Management",
+          "ohjelmat": [
+            {
+              "name": "Bachelor of Engineering 180 ECTS",
+              "opinnot": [
+                "Basic and intermediate studies in information and software engineering 65 ECTS (incl. bachelor's thesis)",
+                "Technology management study package 40 ECTS",
+                "Basic mathematical studies in engineering 35 ECTS",
+                "Communication and language studies 10 ECTS",
+                "Freely selectable study packages, modules and other studies"
+              ]
+            },
+            {
+              "name": "Master of Science in Technology 120 ECTS",
+              "opinnot": [
+                "Advanced studies in technology management 80 ECTS (incl. master's thesis)",
+                "Studies in technology commercialisation 25 ECTS",
+                "Communication and language studies",
+                "Freely selectable studies and modules as well as other studies"
+              ]
+            }
+          ],
+          "link": "https://www.jyu.fi/fi/tule-opiskelemaan/tutustu-aloihimme/tekniikka/teknologiajohtamisen-opinnot"
+        }
+      ]
+    },
+    "hallihaku": {
+      "alt": "Board recruitment",
+      "title": "Board recruitment 2027",
+      "description": "Board recruitment for 2027 has started! Here you can get to know the applicants. Instructions for applying to the board can be found in Algo's announcement channel.",
+      "loading": "Loading applications...",
+      "error": "Error loading applications",
+      "chair": "Board chair",
+      "other": "Other board roles",
+      "emptyChair": "No applications for the board chair yet.",
+      "emptyOther": "No applications for other board roles yet."
+    },
+    "hallitus": {
+      "loading": "Loading...",
+      "error": "Error loading data.",
+      "title": "Board {{year}}",
+      "alt": "Board",
+      "telegram": "Telegram:",
+      "noImage": "No image",
+      "contactIntro": "Psst. if you want to reach the whole board in one message, you can send an email to",
+      "contactMembers": "You can contact individual board members by email at",
+      "staffTitle": "Staff {{year}}"
+    },
+    "jasenedut": {
+      "title": "Member benefits",
+      "intro": "Algo offers its members great benefits! Check below to see which benefits your membership entitles you to. Membership is proven by showing the membership in the KideApp app. ",
+      "passwords": "If a discount code is needed, you can find it on Algo's",
+      "secretsLink": "secrets page",
+      "ask": "You can ask a board member for the password page.",
+      "empty": "More member benefits will be added soon!"
+    },
+    "international": {
+      "title": "Exchange programmes",
+      "erasmusName": "Erasmus (Europe)",
+      "erasmusDescription": "Erasmus offers a 1–2 semester exchange in EU and EEA countries as well as Turkey.",
+      "erasmusLink": "Erasmus programme",
+      "bilateralName": "Bilateral destinations",
+      "bilateralDescription": "Exchanges outside Europe such as America and Asia.",
+      "isepName": "ISEP",
+      "isepDescription": "One application for multiple universities around the world.",
+      "northName": "Nordplus",
+      "northDescription": "Enables exchange to the Nordics and Baltics.",
+      "forthemName": "FORTHEM",
+      "forthemDescription": "Offers short mobilities and Erasmus exchanges within the alliance."
+    },
+    "events": {
+      "empty": "More events coming soon!"
+    },
+    "home": {
+      "introText": "Algo ry is a guild founded in 2022 that brings together students of information and software engineering as well as technology management at the University of Jyväskylä.",
+      "upcomingEvents": "UPCOMING EVENTS",
+      "diamondPartners": "DIAMOND PARTNERS"
+    },
+    "saannot": {
+      "title": "Algo ry rules",
+      "alt": "Rules",
+      "sections": [
+        {
+          "title": "1. Association name and registered office",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The association's name is Algo ry and its registered office is Jyväskylä."
+            }
+          ]
+        },
+        {
+          "title": "2. Purpose and nature of operations",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The purpose of the association is to act as a connecting link for students of information and software engineering and technology management at the University of Jyväskylä, promote their studies, hobbies and common interests, and safeguard the rights of its members as students."
+            },
+            {
+              "type": "heading",
+              "text": "To carry out its purpose, the association may:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "organize courses, exercises and teaching events and other similar activities",
+                "organize competitions, exhibitions, excursions, camps and other events",
+                "organize celebrations, concerts, exhibitions and other occasions",
+                "maintain the association's electronic communication channels",
+                "publish the association's notices and other communications in different communication channels",
+                "advise and guide its members",
+                "collect and share information and carry out research activities",
+                "bring members together in shared activities and maintain contacts with other associations in the field",
+                "maintain a performing group composed of its members",
+                "organize trips related to the association's purpose for its members",
+                "participate in the direct competition costs of members",
+                "acquire the necessary materials and equipment for the association's use",
+                "seek to arrange premises for the use of the association's members",
+                "make proposals and initiatives to increase hobby opportunities",
+                "cooperate with authorities, organizations, companies and private individuals"
+              ]
+            },
+            {
+              "type": "heading",
+              "text": "To support its operations, the association may, where necessary and with the required permission:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "organize fundraising and lotteries",
+                "organize fairs, flea markets and other events",
+                "organize paid events",
+                "receive grants, donations and bequests",
+                "own movable and immovable property necessary for its operations",
+                "carry out café operations",
+                "carry out serving activities in conjunction with events it organizes",
+                "do voluntary work",
+                "sell advertising space",
+                "conclude sponsorship agreements"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "3. Members",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "A natural person who is studying basic or postgraduate studies in information and software engineering or technology management at the University of Jyväskylä, or a person otherwise approved by the board of the association as a member, can be accepted as a regular member. A private person or a competent legal entity that wishes to support the purpose and activities of the association can be accepted as a supporting member. Regular members and supporting members are accepted on application by the association's board. The members are kept in a member register. A member is obliged to notify the board of any changes to their contact information. The association may, upon the proposal of the board, invite a person who has supported the association's activities in an outstanding manner to become an honorary member, provided that the person consents. Honorary membership is lifelong. Acquired membership rights remain."
+            },
+            {
+              "type": "paragraph",
+              "text": "The membership fee for regular members is paid every eight (8) years. A member must resign, or may be expelled by the decision of the board, when their studies in the faculty of IT end. A member may be considered to have resigned if they have not paid their membership fee within one month of the start of a new membership fee period. A member may be removed from membership if the member has failed to pay the membership fee, if the member no longer meets the criteria for membership, or if the member, through their conduct, has caused significant harm to the association or its reputation. The association's board decides on expulsion by a majority vote. A member has the right to resign from the association by notifying the board in writing or by informing the chairperson or by recording the resignation in the minutes of an association meeting."
+            }
+          ]
+        },
+        {
+          "title": "4. Admission and membership fee",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The amount of the admission fee and annual membership fee payable by regular members and supporting members is decided separately for each member category at the spring meeting. Honorary members do not pay membership fees."
+            },
+            {
+              "type": "paragraph",
+              "text": "The collection period for the admission fee and membership fee is 1 September–31 August."
+            }
+          ]
+        },
+        {
+          "title": "5. Board",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The association's affairs are managed by the board, which consists of the chairperson, vice chairperson, secretary, treasurer and up to twenty (20) other regular members elected at the autumn meeting. The chairperson, vice chairperson, secretary, treasurer and any other board members are elected by an absolute majority of votes. If more than two candidates are running for the same position and no one receives more than half of the votes in the first round, a second round is held between the two candidates with the most votes from the first round. In the final vote, a tie is broken by drawing lots."
+            },
+            {
+              "type": "paragraph",
+              "text": "The board's term of office is the calendar year. The board meets at the invitation of the chairperson or, if they are prevented from attending, the vice chairperson, whenever they consider there is reason to do so or when at least half of the board members demand it. The board is quorate when at least half of its members, including the chairperson or vice chairperson, are present. Votes are resolved by an absolute majority. If the votes are tied, the chairperson of the meeting decides, except in elections where lots are drawn."
+            },
+            {
+              "type": "paragraph",
+              "text": "If a member of the board resigns during their term of office, a new member may be elected to replace the resigned member. The new member's term of office lasts until the end of the resigned member's term."
+            },
+            {
+              "type": "paragraph",
+              "text": "All members have the right to attend board meetings without the right to vote."
+            }
+          ]
+        },
+        {
+          "title": "6. Signing the association's name",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The association's name is signed by the chairperson and vice chairperson of the board jointly, or by the corporate relations officer together with the chairperson or vice chairperson."
+            }
+          ]
+        },
+        {
+          "title": "7. Financial year",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The association's financial year is the calendar year. The annual accounts, together with the necessary documents and the board's annual report, must be submitted to the auditor no later than three weeks before the spring meeting. The auditor must provide their written statement to the board no later than one week before the spring meeting."
+            }
+          ]
+        },
+        {
+          "title": "8. Association meetings",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The association holds two regular meetings a year. The spring meeting is held in January–May and the autumn meeting in September–December on a date determined by the board. In association meetings, every regular member has one vote. Supporting members and honorary members have the right to attend and speak at meetings."
+            },
+            {
+              "type": "paragraph",
+              "text": "Unless otherwise specified in the rules, a decision of the association meeting is the opinion supported by more than half of the votes cast. If the votes are tied, the chairperson's vote decides, except in elections where lots are drawn. A meeting is quorate when it has been lawfully convened. Association meetings may be attended by post, telecommunication or another technical means during the meeting or before it, if the board or the association meeting decides so."
+            }
+          ]
+        },
+        {
+          "title": "9. Calling association meetings",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "The board must convene association meetings at least seven days before the meeting by email to the address provided by the member and via a social media channel intended for members."
+            }
+          ]
+        },
+        {
+          "title": "10. Regular meetings",
+          "content": [
+            {
+              "type": "heading",
+              "text": "The following matters are handled at the association's spring meeting:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "the financial statements and auditors' report are presented",
+                "the financial statements are approved and discharge is granted to the board and other responsible persons",
+                "the amounts of membership and admission fees for the next collection period are approved (defined in section 4. 'Admission and membership fee')"
+              ]
+            },
+            {
+              "type": "heading",
+              "text": "The following matters are handled at the association's autumn meeting:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "the action plan and income and expenditure budget are approved",
+                "the chairperson and other members of the board are elected",
+                "one or two auditors and a deputy auditor are elected"
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "If a member of the association wants a matter to be processed at a spring or autumn meeting, they must notify the board in writing well in advance so that the matter can be included in the meeting notice."
+            }
+          ]
+        },
+        {
+          "title": "11. Changing the rules and dissolving the association",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "A decision to amend the rules or dissolve the association must be made at an association meeting by at least a three-fourths (3/4) majority of the votes cast. The meeting notice must state that the rules will be amended or the association dissolved. If the association is dissolved, its assets shall be given to a charity or other public-benefit purpose chosen by the meeting. If the association is dissolved, its assets are used for the same purpose."
+            }
+          ]
+        }
+      ]
+    },
+    "vuju": {
+      "title": "Annual celebration etiquette",
+      "alt": "Annual celebrations",
+      "intro": "Algo officially turns a year older on 4 July, but its annual celebration is traditionally celebrated in the autumn. The annual celebration is our guild's most valuable academic event, and it is attended accordingly. The celebrations are open to both Algo members, invited guests and avecs. This etiquette introduces the guests to the practices of the annual celebrations so that there is no need to worry about practical matters during the celebration itself.",
+      "sections": [
+        {
+          "heading": "Dress code",
+          "text": "At the annual celebration, one dresses either in a tailcoat, a dark suit or an evening gown.\n\n**Tailcoat** consists of a black tailcoat and trousers, a white waistcoat, a white shirt with pearl buttons, and a white bow tie. With a tailcoat, black socks and black patent leather shoes are worn. A wristwatch is not recommended with a tailcoat. A tuxedo or other variations are not an appropriate choice for a tailcoat.\n\n**Dark suit** means a dark grey, dark blue or black suit. The suit can be plain or subtly striped, but not a pinstripe. A white or pale pink shirt (other light colours also work well), a festive tie or bow tie, black shoes and dark, long socks are worn with the dark suit.\n\n**Evening gown** is a formal ankle- or floor-length dress made of formal material. The evening gown may be open, closed, strapless or long-sleeved. With an evening gown, one may also wear a shawl, elbow-length gloves or a strapless bag. During the meal it is not appropriate to place the bag on the table or keep gloves on the hands.\n\nAcademic insignia and a celebration ribbon can complement the attire. According to section 10 of the feast ribbon and badge regulations:\n\n*“The feast ribbon as well as the honour, merit and board badges are used only in formal academic occasions. The feast ribbon is worn so that it runs from the right shoulder across the chest to the left hip, with the light pink colour above. The feast ribbon is worn under the waistcoat in a tailcoat and over the waistcoat and tie in a dark suit. With a dress, the feast ribbon may be carried folded as a rose on the left side of the chest, with the light pink colour on top, or as in a tailcoat. The feast ribbon must not touch bare skin.”*\n\n*At Algo ry's own events, the feast ribbon is worn highest if the bearer also has ribbons from other organisations. In other events, the applicable regulations are followed.*\n\n*Honour, merit and board badges may be worn simultaneously with the feast ribbon, and their arrangement does not matter.*"
+        },
+        {
+          "heading": "Noble celebration behaviour",
+          "text": "The annual celebration is above all an academic table celebration, where proper table manners are a requirement. A seating arrangement has been made, and everyone's place is marked with a name card. If there are people at your table whom you do not know, it is polite to introduce yourself first and keep the conversation going with others besides familiar faces throughout the event.\n\nThe ceremony masters are responsible for the flow of the celebration; they should be listened to. During speeches, songs and other programme, one must remain quiet and not eat. Plenty of time is reserved for socializing, so there is time to talk. Tribute to speeches and other programme is expressed by clapping hands.\n\nWhen toasting, i.e. when raising a glass, one first looks at the person sitting to the left on the other side of the table, then the person sitting to the right on the other side of the table, and finally the person sitting directly opposite. When raising the glass, glasses must not touch each other; the clinking is replaced by a small nod.\n\nYou may leave for breaks only during the breaks marked in the programme. If there is an unavoidable need to leave your place at another time, it should be done quietly and apologetically to the table company, and under no circumstances during speeches or performances.\n\nIt is not appropriate to be late for the celebration; therefore, arrive in good time."
+        },
+        {
+          "heading": "The course of the celebration",
+          "text": "The celebration traditionally begins with a cocktail reception, i.e. a cocktail party. Only invited guests are invited to this event, meaning guests who have received a separate invitation to the celebration. Such guests include, for example, honorary members of the guild, teachers and representatives of other guilds or student organizations. At the cocktail reception, invited guests take turns giving congratulatory speeches to Algo on its birthday and presenting gifts. Usually sparkling wine and small snacks are served. The event is usually a standing event and lasts about two hours.\n\nFrom the cocktail reception, one moves directly to the main celebration. Everyone who has bought a ticket to the annual celebration is invited to the main celebration. The celebration begins when the flag party brings the Finnish flag into the celebration hall. At this point, the guests rise and wait in silence for the flag to be placed, after which the song Finlandia is sung together. At this stage, the ceremony masters introduce themselves and give general instructions. After that, Helan Går is sung, and the opening shot is enjoyed. After the songs, welcome speeches are heard and the celebration can begin.\n\nAfter the opening speeches, socializing and singing begin. Songs and speech requests can be made by clinking your own glass. Usually the songs are requested from the songbook distributed at your seating place. For the main course, a meal break is declared, during which songs may still be requested, but eating during songs is allowed as an exception. However, it is not appropriate to sing with food in your mouth. Before and after the meal, there is all kinds of programme: speeches, awards, performances and singing. In the latter part of the celebration, dessert is eaten and coffee is usually enjoyed with an avec. In this context, avec can mean something like cognac or liqueur. During dessert, the Jallu shot is raised and the song Jallutähden alla is sung. The celebration ends with the chairperson's words and the carrying out of the Finnish flag.\n\nAt the cocktail reception and the main celebration, there is usually a photographer who takes pictures in front of the photo wall as well as during the celebration itself. The pictures are delivered to the guests afterwards in the way chosen by the event organizers.\n\nWhen the main celebration ends, the fun does not diminish; rather, the celebration continues at the official afterparties. At the annual celebration, there may be drink tickets available and the cloakroom is usually paid in advance, which makes the move to the after-parties smoother. At midnight, the celebration crowd gathers in a dimmed room to sing the teekkari hymn."
+        },
+        {
+          "heading": "Academic silliaamiainen",
+          "text": "Recovery after the annual celebrations takes place at the silliaamiainen, i.e. the post-celebration breakfast, which is held the day after the annual celebration. It is held in a relaxed place, such as the sauna at Opinkivi. The silliaamiainen usually offers greasy food and refreshments, and the dress code is overalls."
+        }
+      ]
+    },
+    "kunniagalleria": {
+      "alt": "Hall of fame",
+      "honoraryTitle": "Algo ry honorary members",
+      "honoraryDescription": "An honorary member is a person who has supported the guild's activities in an especially meritorious way. Honorary membership is Algo's highest honour.",
+      "yearlyTitle": "Winners of the Year Algolainen award",
+      "yearlyDescription": "Year Algolainen is chosen by vote among the members and is a person who has shown significant interest in the association's activities and promoted cohesion among members.",
+      "previousBoards": "You can see previous boards",
+      "here": "here"
+    },
+    "aktiivit": {
+      "alt": "Active members",
+      "title": "WHAT ON EARTH IS AN ACTIVE???",
+      "description": "Active members are members of our guild who want to help and influence the activities of our guild. Active members support our board members with a low threshold.",
+      "rolesTitle": "ACTIVE ROLES",
+      "interestedTitle": "Interested?",
+      "interestedDescription": "Apply to become an active by filling in the form below!",
+      "applyButton": "Apply as an Active",
+      "badgesTitle": "Active badges",
+      "teams": [
+        {
+          "title": "Events team",
+          "tasks": [
+            {
+              "title": "Planning and organizing events",
+              "subTasks": [
+                "Includes arranging and organizing the event venue and general event planning"
+              ]
+            },
+            { "title": "Designing event badges" },
+            { "title": "Organizing sports events" },
+            { "title": "Maintains the events team" }
+          ],
+          "responsibles": [
+            { "nimi": "Event coordinator(s)", "href": "/hallitus" }
+          ]
+        },
+        {
+          "title": "Corporate collaboration team",
+          "tasks": [
+            {
+              "title": "Contacting and acquiring companies",
+              "subTasks": [
+                "Also includes obtaining small one-off sponsors"
+              ]
+            },
+            { "title": "Maintains the corporate collaboration team" }
+          ],
+          "responsibles": [
+            { "nimi": "Corporate relations officer", "href": "/hallitus" }
+          ]
+        },
+        {
+          "title": "Social media and communication team",
+          "tasks": [
+            {
+              "title": "Maintaining social media channels",
+              "subTasks": ["Instagram & TikTok"]
+            },
+            { "title": "Capturing events" },
+            { "title": "Promoting the guild" },
+            { "title": "Guild member communication by email" },
+            { "title": "Maintains the social media and communication team" }
+          ],
+          "responsibles": [
+            { "nimi": "Communications officer", "href": "/hallitus" }
+          ]
+        }
+      ],
+      "other": [
+        { "title": "Equality representative at events" },
+        {
+          "title": "Festival team",
+          "subTasks": ["Organizing Vappu and annual celebrations"]
+        },
+        {
+          "title": "Webmaster",
+          "subTasks": [
+            "Updating and maintaining the website",
+            "Maintaining subdomain applications",
+            "Maintaining the server"
+          ]
+        },
+        {
+          "title": "More information about various active tasks can be asked from a board member"
+        }
+      ]
+    },
+    "kerhotoiminta": {
+      "title": "Club activities",
+      "intro": "Club activities are self-organized by members and can relate to hobbies, community building, or study support. All members can participate in clubs or help start one.",
+      "sectionTitle": "Algo's clubs",
+      "infoPrefix": "For more details about the club and schedules, join the club's Telegram group:",
+      "kerhot": {
+        "kyykkä": {
+          "name": "Kyykkä club",
+          "description": "The Kyykkä club offers a fun and community-oriented way to try Kyykkä. The activity is open to all members regardless of skill level.",
+          "linkText": "Let's Kyykkä!",
+          "linkHref": "https://t.me/+0nivuYqDLzUxYjNk"
+        },
+        "futis": {
+          "name": "Football club",
+          "description": "Algo FC offers a chance to play football in a relaxed and community-oriented atmosphere. The activity is open to all members regardless of skill level – newcomers and experienced players are both welcome. ⚽",
+          "linkText": "Let's play!",
+          "linkHref": "https://t.me/+IhWC1RJ9ZGM0OGU0"
+        }
+      },
+      "newClub": {
+        "title": "Want to start a new club?",
+        "description": "Starting a new club can be done with the following steps:",
+        "steps": [
+          {
+            "title": "Draft an initial action plan",
+            "points": [
+              "What topic or activity the club relates to",
+              "The purpose and target group of the club",
+              "What events, meetings or other activities are planned",
+              "What benefits the club brings to the members and what goals it has"
+            ]
+          },
+          {
+            "title": "Contact the chairperson of the board and arrange a meeting where ideas can be discussed and developed together."
+          },
+          {
+            "title": "If the club is seen to have a clear need and potential, prepare a more detailed action plan for the board meeting."
+          },
+          {
+            "title": "The board makes the decision on establishing the club at its meeting."
+          }
+        ]
+      },
+      "support": {
+        "title": "What support do clubs receive?",
+        "description": "Approved clubs operate officially under the association and may receive support in the following ways:",
+        "points": [
+          "Coverage of activity-related costs",
+          "Use of Algo's communication channels (e.g. Telegram and newsletters)",
+          "Ability to request further support as needed – feel free to contact the club representative!"
+        ]
+      }
+    },
+    "ohjesaannot": {
+      "intro": "From this page you can find information about the teekkari rulebook, the overalls etiquette, and the feast ribbon and badge regulations.",
+      "title": "Feast ribbon and badge regulations",
+      "rules": [
+        "1§ Algo ry has the honour, merit, board, and yearly Algo member badge as well as a feast ribbon, which are described below. The model copies of the badges are kept in the association archive, and a list is maintained of all awarded and distributed badges, their award criteria, and dates.",
+        "2§ The board decides on granting badges. The board may grant more badges than the maximum allowed under this regulation if the board decides on it unanimously. If the proposal is not approved, no entry is made in the minutes.",
+        "3§ On the proposal of the board, the association may invite a person who has supported the association's activities in an outstanding manner to become a honorary member, provided that the person consents. The honorary member is awarded a certificate signed by the current chairperson and is invited to the association's annual celebrations every year, if such events are held. Honorary membership is lifelong.",
+        "4§ A badge of honour can be awarded to a person who has significantly contributed to the activities of the association through long-term activity or an exceptionally significant deed. The badge of honour is also awarded to every honorary member either when they are granted honorary membership or retroactively. Up to three (3) badges of honour may be awarded annually. The badge of honour is golden and measures xx mm.",
+        "5§ A merit badge can be awarded to a person who has promoted the association's activities in an outstanding manner over the last year. Up to five (5) merit badges may be awarded annually. The merit badge is silver and measures xx mm.",
+        "6§ The board badge is awarded to current members of the board. The board badge may also be awarded to former members of the board. The board badge is silver and measures 16 mm.",
+        "7§ The yearly Algo member badge is awarded to a member of Algo ry who has shown significant interest in the association's activities and promoted cohesion among members. The member is selected annually through a vote in which every member of Algo ry is entitled to vote. Members are informed via the association's official communication channels no later than 2 weeks before the badge presentation event. An individual may only receive the badge once. The yearly Algo member badge is a patch with a diameter of 80 mm and a purple color with a yellow rosette.",
+        "8§ Awards and certificates granted are presented to recipients at the association's annual celebrations, annual celebration gala or another worthy event deemed suitable by the board. The right to use all badges granted by Algo ry is lifelong.",
+        "9§ The feast ribbon is 35 mm wide and light pink and white in color. Every regular member of the association is entitled to use the ribbon, and it can be purchased directly from the association. The feast ribbon is granted free of charge alongside the merit badge if the deserving person does not already have one. The right to use the feast ribbon remains after leaving the association.",
+        "10§ The feast ribbon as well as the honour, merit, and board badges are used only in formal academic occasions.",
+        "11§ This regulation was approved by the association's meeting on 26.5.2023. It is valid indefinitely. Changes to this regulation are decided by the association's meeting by an absolute majority vote."
+      ],
+      "haalarietiketti": {
+        "title": "Overall etiquette",
+        "paragraphs": [
+          "Overalls are recommended to be worn up, fully worn. They are used at all student events unless otherwise stated in the dress code. When overalls are worn at the waist, the back part is folded so that the association logo is visible. Overalls can and should be customized to one's liking.",
+          "Overalls patches should be sewn by hand. They should not be glued or sewn with a sewing machine. In addition, patches should not be sewn over sponsors' logos when space is available.",
+          "Overalls should not be washed in a washing machine or in any similar way. Overalls are washed by being inside you, for example in a lake or shower."
+        ]
+      },
+      "teekkari": {
+        "title": "Teekkari cap",
+        "imageAlt": "Eight-sided Jyväskylä teekkari cap",
+        "description": "The Jyväskylä teekkari cap is eight-sided, following the shape of the Kompass building on Jyväskylä's walking street. The inside of the cap is blue-orange matching the colors of the University of Jyväskylä. The rosette of the cap combines Jyväskylä and technology, as the rosette features the JYY torch surrounded by the technology ring. First-year engineering students, i.e. freshmen, become teekkaris in spring when, after the baptism, they may wear the cap. The wearing period begins with the spring baptism and ends on the last day of September at the cap-lowering event.",
+        "linkText": "Jyväskylä teekkari association",
+        "linkText2": "cap use permit"
+      }
+    },
+    "periaatteet": {
+      "title": "About the activity",
+      "intro": "Within Algo, help can be sought from the social policy / education policy contacts (sopo@algojkl.com & kopo@algojkl.com) or anonymously via the form you can find",
+      "formLink": "here",
+      "support": "Responses to the form are only visible to the social policy / education policy contacts.",
+      "summaryTitle": "About the activity:",
+      "summary": "Algo does not tolerate any discrimination or harassment in its own operations and we strive to build a supportive atmosphere. If you encounter misconduct, harassment, discrimination, or feel unsafe, speak up and ask for help. Support and help are always available if you need it.",
+      "valuesTitle": "Algo and its members are committed to the following values:",
+      "values": [
+        "All people are equal regardless of gender, age, ethnic or national origin, citizenship, language, religion, sexual orientation or any other personal reason",
+        "No pressure is applied to use intoxicants.",
+        "Good manners are followed and conduct is professional.",
+        "Different perspectives are understood and respected.",
+        "A healthy teekkari spirit is maintained, created and developed.",
+        "Everyone enjoys their study period on their own terms and in accordance with the principles above and Finnish law.",
+        "The principles of a safe space are followed (below)."
+      ],
+      "safetyTitle": "Algo ry's safe space principles:",
+      "safety": [
+        "Stop disruptive behaviour immediately and apologize right away.",
+        "Make sure everyone can participate and feel heard when they want to.",
+        "Do not disturb anyone verbally, physically, or by staring.",
+        "Everyone can participate and share as much as they want.",
+        "Give space and handle sensitive matters respectfully.",
+        "Do not make assumptions about people's outward characteristics.",
+        "Avoid discriminatory stereotypes in your speech and actions.",
+        "Respect personal space and boundaries.",
+        "We intervene in inappropriate and disruptive behaviour."
+      ],
+      "equalityTitle": "Equality:",
+      "equality": "Algo strives to create the safest, most reliable, and most equal environment possible for every member. The Universities Act states that universities must provide a safe study environment where everyone has the right to study without experiencing harassment, bullying, or discrimination (Universities Act 41§). Algo ry does not tolerate bullying, discrimination, harassment, or any other improper behaviour at its events in any form. We want to promote a safe and pleasant higher education community for everyone. It is not always possible to avoid bullying or harassment. Therefore, it is absolutely essential to react to bullying situations. At the University of Jyväskylä, you can seek help from Hyvikset, for example, who provide discussion support and guide you forward if needed. Help is also available from JYY's harassment contact persons or from the social policy contact. All information shared is confidential and will not be discussed with anyone without the individual's permission."
+    },
+    "pestit": {
+      "title": "Short descriptions of board roles",
+      "ps": "ps: The board works together on more than just its own responsibilities.",
+      "previous": "You can see previous boards",
+      "here": "here",
+      "roles": [
+        {
+          "title": "Chairperson",
+          "description": "is responsible for the board's operations, leads board meetings and represents the association in general."
+        },
+        {
+          "title": "Vice chairperson",
+          "description": "substitutes for the chairperson when needed and works closely with the chairperson."
+        },
+        {
+          "title": "Secretary",
+          "description": "writes the minutes at meetings (official document of the matters discussed during meetings)."
+        },
+        {
+          "title": "Treasurer",
+          "description": "pays invoices, takes care of accounting and is responsible for the association's bank account."
+        },
+        {
+          "title": "Corporate relations officer",
+          "description": "establishes and maintains cooperation agreements with companies and is responsible for the business team."
+        },
+        {
+          "title": "Events officer",
+          "description": "plans and organizes events and is responsible for the event team."
+        },
+        {
+          "title": "Project officers",
+          "description": "take care of project-based events related to teekkari culture such as annual celebrations, cap-lowering events, and baptism celebrations."
+        },
+        {
+          "title": "Education policy officer",
+          "description": "(kopo) ensures students' rights are respected and maintains relationships with the university."
+        },
+        {
+          "title": "Social policy officer",
+          "description": "(sopo) looks after students' rights, well-being and equality in the association."
+        },
+        {
+          "title": "Club officer",
+          "description": "is responsible for communication between clubs and the board."
+        },
+        {
+          "title": "Communications officer",
+          "description": "maintains the association's social media channels and informs members about events and other important matters."
+        }
+      ]
+    },
+    "rekisteriseloste": {
+      "title": "Member register privacy notice",
+      "sections": [
+        {
+          "title": "1. Controller",
+          "content": "Algo ry / Faculty of Information Technology\nPL 35 (Agora)\n40014 University of Jyväskylä"
+        },
+        {
+          "title": "2. Contact person responsible for the register",
+          "content": "Secretary of Algo ry (sihteeri@algojkl.com)"
+        },
+        {
+          "title": "3. Name of the register",
+          "content": "Association member register."
+        },
+        {
+          "title": "4. Legal basis and purpose of processing personal data",
+          "content": "The legal basis for processing personal data under the EU General Data Protection Regulation is the controller's legitimate interest (membership). The purpose of processing personal data is communicating with members as well as verifying membership when required (e.g. statutory meeting). The data is not used for automated decision-making or profiling. According to the Associations Act, the association board must keep a list of members."
+        },
+        {
+          "title": "5. Contents of the register",
+          "content": "Data stored in the register includes: person's name, contact details (email address), place of residence."
+        },
+        {
+          "title": "6. Regular sources of information",
+          "content": "Data stored in the register is obtained from messages sent by members through web forms or during meetings."
+        },
+        {
+          "title": "7. Regular transfers and transfer outside the EU or EEA",
+          "content": "Data is not regularly disclosed to third parties."
+        },
+        {
+          "title": "8. Principles of data protection",
+          "content": "Carefulness is exercised in the processing of the register, and data processed via information systems is appropriately protected. When register data is stored on internet servers, the physical and digital security of the equipment is handled appropriately. The controller ensures that stored data and server access rights and other critical information for the security of personal data are handled confidentially and only by those persons whose job description includes it."
+        },
+        {
+          "title": "9. Right of inspection and right to request correction",
+          "content": "Every person in the register has the right to check data stored in the register and request correction or completion of inaccurate or incomplete data. If a person wishes to check data stored about them or request correction, the request must be sent in writing to the controller. Where necessary, the controller may request the applicant to prove their identity. The controller will respond to the customer within the time prescribed by the EU Data Protection Regulation."
+        },
+        {
+          "title": "10. Other rights related to processing personal data",
+          "content": "A person in the register has the right to request the removal of their personal data from the register (the right to be forgotten). Likewise, registered persons have other rights under the EU General Data Protection Regulation, such as restricting the processing of personal data in certain situations. Requests must be sent in writing to the controller. Where necessary, the controller may request the applicant to prove their identity. The controller will respond to the customer within the time prescribed by the EU Data Protection Regulation."
+        }
+      ]
+    },
+    "toimari": {
+      "noImage": "No image"
+    },
+    "rekryt": {
+      "alt": "Recruitment",
+      "loading": "Loading job postings...",
+      "error": "Error loading job postings",
+      "title": "Open job postings will be published here!",
+      "moreInfo": "More information here!",
+      "empty": "There are no active job postings at the moment."
+    },
+    "prevHalli": {
+      "boardTitle": "Board {{year}}"
+    },
+    "salaisuudet": {
+      "prompt": "Enter the password to access the content:",
+      "placeholder": "Password",
+      "loginButton": "Log in",
+      "wrongPassword": "Incorrect password",
+      "serverError": "Server error: {{message}}",
+      "loading": "Loading content..."
+    },
+    "tapahtumat": {
+      "alt": "Events",
+      "title": "Upcoming events",
+      "description": "Event sign-ups and more details can be found on Algo ry's announcement channel on Telegram. You can join Algo's Telegram channels through member newsletters sent by email or by asking board members.",
+      "calendarTitle": "Google Calendar"
+    },
+    "yhteistyo": {
+      "alt": "Collaboration",
+      "title": "Hi! Interested in collaboration?",
+      "intro": "You can collaborate with Algo in all kinds of ways! Do you want an advertising spot on our overalls or want to sponsor our events? Or would you like to present your company to Jyväskylä's Master's students?",
+      "contactUs": "Get in touch!",
+      "corporate": "Corporate partnerships",
+      "events": "Events",
+      "external": "Guild external relations",
+      "otherIdeas": "Other ideas?",
+      "otherDescription": "You can always suggest new collaboration ideas to us!",
+      "otherContact": "For other collaboration inquiries, you can contact our chairperson:",
+      "partnersTitle": "In collaboration with"
+    },
+    "yhteydenotto": {
+      "alt": "Contact",
+      "general": {
+        "title": "General feedback form",
+        "description": "You can share feedback here — both positive and negative. About Algo's operations, websites, or anything related to our association.",
+        "linkLabel": "Feedback form"
+      },
+      "course": {
+        "title": "Course feedback",
+        "description": "One of Algo ry's most important tasks is advocacy, and the association aims to influence the development of teaching. With this form, you can give feedback on a specific course related to teaching, assessment, or anything else. This feedback does not replace the university's official or teacher-provided course feedback form!",
+        "warning": "This feedback does not replace the official university or teacher-provided course feedback form!",
+        "description2": "This feedback is collected and used by Algo's education policy officer and chairperson. You can give this feedback completely anonymously or provide your contact details if you want to be contacted. However, the feedback is still forwarded entirely anonymously.",
+        "linkLabel": "Course feedback form",
+        "linkPrefix": "Link to the form"
+      }
+    }
+  },
+  "footer": {
+    "sections": {
+      "navigation": "NAVIGATION",
+      "staff": "STAFF",
+      "officialDocuments": "OFFICIAL DOCUMENTS",
+      "members": "MEMBERS"
+    },
+    "contactTitle": "Contact information",
+    "addressLine1": "Mattilanniemi 2,",
+    "addressLine2": "40100 Jyväskylä",
+    "email": "pj@algojkl.com",
+    "vat": "Business ID: 3297709-4",
+    "feedbackTitle": "Would you like to give us feedback?",
+    "feedbackDescription": "You can do that by filling out the form below. Feedback is handled anonymously.",
+    "feedbackLink": "Feedback form"
+  }
+}

--- a/algojkl-frontend/src/locales/fi/common.json
+++ b/algojkl-frontend/src/locales/fi/common.json
@@ -1,0 +1,912 @@
+{
+  "nav": {
+    "brand": "Algo ry",
+    "menu": "KILTA",
+    "events": "TAPAHTUMAT",
+    "collaboration": "YHTEISTYÖ",
+    "fuksit": "FUKSIT",
+    "applicants": "HAKIJAT",
+    "sections": {
+      "staff": "TOIMIHENKILÖT",
+      "officialDocuments": "VIRALLISET DOKUMENTIT",
+      "members": "JÄSENILLE"
+    },
+    "links": {
+      "board": "HALLITUS",
+      "active": "AKTIIVIT",
+      "rules": "SÄÄNNÖT",
+      "guidelines": "OHJESÄÄNNÖT & ETIKETIT",
+      "vuju": "VUOSIJUHLAT",
+      "privacy": "REKISTERISELOSTE",
+      "honours": "KUNNIAGALLERIA",
+      "principles": "TOIMINNAN PERIAATTEET",
+      "benefits": "JÄSENEDUT",
+      "clubs": "KERHOTOIMINTA",
+      "recruitment": "REKRYT",
+      "forms": "YHTEYDENOTTOLOMAKKEET",
+      "international": "KANSAINVÄLISYYS",
+      "kattila": "KATTILAN KAHVIKAMERA",
+      "secrets": "SALAISUUDET",
+      "songbook": "LAULUKIRJA",
+      "home": "ETUSIVU",
+      "documents": "DOKUMENTIT",
+      "formsShort": "LOMAKKEET"
+    },
+    "language": {
+      "fi": "FI",
+      "en": "EN",
+      "toggle": "Valitse kieli"
+    },
+    "joinButton": "LIITY JÄSENEKSI"
+  },
+  "pages": {
+    "kansainvalisyys": {
+      "title": "Algolaisen vaihtovinkit ja linkit",
+      "alt": "Kansainvälisyys",
+      "yearClockTitle": "Vaihtoon lähtemisen vuosikello",
+      "months": {
+        "january": {
+          "title": "Tammikuu",
+          "intro": "Infotilaisuuksia järjestetään yleensä tammikuun puolivälin jälkeen, jolloin saat kattavan kuvan vaihto-ohjelmista ja -mahdollisuuksista.",
+          "searches": "Tammikuussa alkavat haut:",
+          "search1": "22.1. – 5.2. Haku Euroopan vaihtokohteisiin (Erasmus, Nordplus, Nordlys).",
+          "search2": "22.1. – 5.2. Lisähaku Euroopan ulkopuolisiin kohteisiin."
+        },
+        "febMarch": {
+          "title": "Helmi- ja Maaliskuu",
+          "body": "Näiden kuukausien aikana ei ole varsinaisia hakuaikoja, mutta voit käyttää aikaa hakemuksen valmisteluun ja vaihtokohteen suunnitteluun."
+        },
+        "april": {
+          "title": "Huhtikuu",
+          "body": "1.4. – 31.5. Täydennyshaku Erasmus-opiskelijavaihtoon. Hakemuksia käsitellään juoksevasti koko hakuajan ajan."
+        },
+        "september": {
+          "title": "Syyskuu",
+          "body": "2.9. – 30.9 Täydennyshaku Erasmus- ja Nordplus-vaihtoon kevätlukukaudeksi 2025."
+        },
+        "october": {
+          "title": "Lokakuu",
+          "body": "1.10. – 1.11. Haku Euroopan ulkopuolisiin vaihtokohteisiin, mukaan lukien ISEP-vaihto."
+        },
+        "mayDecember": {
+          "title": "Touko- ja joulukuu",
+          "body": "Hae matka-apurahaa, jos olet löytänyt harjoittelupaikan ulkomailta. Hakuajat vaihtelevat vuosittain."
+        },
+        "allYear": {
+          "title": "Ympäri vuoden",
+          "body": "Erasmus-harjoitteluapuraha on haettavissa koko vuoden ajan. Huomioi kuitenkin käsittelyajat."
+        }
+      },
+      "tips": {
+        "title": "Vaihtovinkit",
+        "creditsLabel": "Opintopistevaatimukset:",
+        "creditsText": "Suorita yleensä vähintään 20 op per lukukausi.",
+        "studyPlanLabel": "Kurssisuunnitelma:",
+        "studyPlanText": "Tee Learning Agreement ja hyväksytä se molemmissa yliopistoissa.",
+        "studyPlanPoint1": "Suunnitelma on alustava ja sitä voi muuttaa vaihdon aikana.",
+        "studyPlanPoint2": "Kurssit voivat muuttua ilmoittautumisen yhteydessä.",
+        "levelLabel": "Opintotasojen huomioiminen:",
+        "levelPoint1": "Valitse kurssitaso (kandi/maisteri) tavoitteidesi mukaan.",
+        "levelPoint2": "Kandikurssit usein paikallisella kielellä, maisterikurssit englanniksi.",
+        "levelPoint3": "Joissain tapauksissa tarvitaan todistus oikeudesta suorittaa maisteritason opintoja."
+      },
+      "sites": {
+        "title": "Sivustot",
+        "mobilityLabel": "Hakuprosessi Mobility Online -portaalissa:",
+        "mobilityLink": "Mobility Online -portaali",
+        "applicationLabel": "Ohjeita hakuvaiheeseen:",
+        "applicationLink": "Step by step -hakuohjeet",
+        "preparationLabel": "Valmistautuminen vaihtoon:",
+        "preparationLink": "Valmistautumisohjeet",
+        "fundingLabel": "Vaihdon rahoitus:",
+        "fundingLink": "Vaihdon rahoitus"
+      },
+      "languageCertificates": {
+        "title": "Kielitodistukset",
+        "body": "Monet vaihtokohteet saattavat vaatia kielitodistuksen. Kielitodistuksia voi hankkia Movilta. Lisätietoja saa ottamalla yhteyttä Niina Ormashawiin."
+      }
+    },
+    "notFound": {
+      "title": "Sivua ei löytynyt",
+      "description": "Etsimääsi sivua ei ole olemassa. Tarkista osoite tai palaa etusivulle.",
+      "backHome": "Palaa etusivulle"
+    },
+    "sopokopo": {
+      "title": "Sopo-Kopo Yhteydenottolomake",
+      "description": "Tällä lomakkeella voit ottaa yhteyttä jos olet kokenut asiatonta käytöstä, väärinkäytöksiä opetuksessa tai haluat muuten vain kertoa ongelmistasi. Voit halutessasi jättää yhteystietosi jos haluat että Algon hyvinvointivastaava/sopo/kopo on sinuun asian tiimoilta yhteydessä. Muutoin vastaukset tähän lomakkeeseen käsitellään luottamuksellisesti ja anonyymisti. Vaikka jättäisit yhteystietosi, asiasi käsitellään anonyymisti. Vain sopo/kopo näkee yhteystietosi.",
+      "formLinkLabel": "Linkki lomakkeeseen:",
+      "formLinkText": "SopoKopoLomake"
+    },
+    "perustajat": {
+      "title": "Perustajajäsenet & Hallitus {{year}}"
+    },
+    "personCard": {
+      "named": "Nimetty {{year}}"
+    },
+    "eventCards": {
+      "showLess": "NÄYTÄ VÄHEMMÄN",
+      "showLessAria": "Näytä vähemmän tapahtumia",
+      "showMore": "NÄYTÄ LISÄÄ TAPAHTUMIA",
+      "showMoreAria": "Näytä lisää tapahtumia"
+    },
+    "eventModal": {
+      "tickets": "Liput",
+      "dateLabel": "Päivämäärä"
+    },
+    "fuksit": {
+      "alt": "Fuksit",
+      "title": "Heippa teekkarifuksi!",
+      "subtitle": "Teekkarifuksi* ~: cd /fuksisyksy",
+      "typewriter": "*Teekkarifuksi on ensimmäistä vuotta opiskeleva henkilö, joka teekkarikasteen suoritettuuan voi kutsua itseään teekkariksi.",
+      "loading": "Ladataan...",
+      "error": "Virhe ladattaessa tietoja!",
+      "beforeStudiesTitle": "Ennen opiskeluiden alkua:",
+      "important": "Koko opiskeluajan tärkein asia: Seuraa sähköpostia!",
+      "studyStartTitle": "Opintojen alku",
+      "guildActivityTitle": "Kiltatoiminta",
+      "membershipTitle": "Jäsenyys",
+      "tutorTitle": "Tutorit 2026 esittäytyvät:",
+      "tutorNote": "Suomenkieliset tutorit esittäytyvät suomeksi ja englanninkieliset tutorit englanniksi.",
+      "beforeStudies": [
+        {
+          "title": "Ota opiskelupaikka vastaan",
+          "description": "Opiskelupaikka tulee olla vastaanotettu viimeistään 9.7.2026 klo 15.00. Opiskelupaikka vastaanotetaan Oma Opintopolku -palvelussa."
+        },
+        {
+          "title": "Ilmoittaudu läsnäolevaksi ja maksa ylioppilaskunnan jäsenmaksu",
+          "description": "Ilmoittautuminen lukuvuodelle läsnäolevaksi tapahtuu OILI-ilmoittautumispalvelussa. Samalla maksetaan ylioppilaskunnan jäsenmaksu.",
+          "link": {
+            "href": "https://oili.csc.fi/",
+            "text": "OILI-ilmoittautumispalvelu"
+          }
+        },
+        {
+          "title": "Korkeakouluopiskelijan terveydenhoitomaksu",
+          "description": "Muista maksaa korkeakouluopiskelijan terveydenhoitomaksu. Tämä maksu on pakollinen jokaiselle opiskelijalle riippumatta siitä, käyttääkö opiskelija terveydenhuoltopalveluita vai ei.",
+          "link": {
+            "href": "https://www.kela.fi/korkeakouluopiskelijan-terveydenhoitomaksu",
+            "text": "Lisätietoa"
+          }
+        },
+        {
+          "title": "Hae asuntoa",
+          "description": "Soihtu ja Koas tarjoavat sopuhintaisia opiskelija-asuntoja. Kannattaa tehdä asuntohakemukset laajilla hakukriteereillä, jotta asunnon saamiseen menisi vähemmän aikaa. Tarkempia ohjeita löydät JYY:n sivuilta.",
+          "links": [
+            { "href": "https://soihtu.fi/", "text": "Soihtu" },
+            { "href": "https://www.koas.fi/fi/", "text": "Koas" }
+          ]
+        },
+        {
+          "title": "Hae Kelalta tukia",
+          "description": "Muista hakea Kelalta opinto- ja asumistukea.",
+          "link": {
+            "href": "https://www.kela.fi/opiskelijat-pikaopas",
+            "text": "Kelan pikaopas"
+          }
+        },
+        {
+          "title": "Tilaa opiskelijakortti",
+          "description": "Opiskelijakortilla saat merkittäviä alennuksia jokapäiväisistä asioista. Esimerkiksi opiskeijaruokailun hinta on opiskelijakortilla 3.10€ (normaalisti 9,00€). Tällä hetkellä ylioppilaskunnan opiskelijakortteina toimivat Slice ja Frank. Slicen käyttöönotto onnistuu osoitteessa slice.fi/jyy, ja Frankin osoitteessa frank.fi/opiskelijakortti. Lisätietoa opiskelijakorteista löytyy JYY:n sivuilta.",
+          "links": [
+            { "href": "https://slice.fi/jyy", "text": "Slice" },
+            { "href": "https://frank.fi/opiskelijakortti", "text": "Frank" },
+            { "href": "https://jyy.fi/opiskelijalle/opiskelijakortti", "text": "JYY" }
+          ]
+        }
+      ],
+      "studyStart": [
+        "Orientaatioviikko tieto- ja ohjelmistotekniikan sekä teknologiajohtamisen koulutusohjelmissa alkaa 24.8.2026 Jyväskylän yliopiston IT-tiedekunnassa Agoralla."
+      ],
+      "guildActivity": [
+        "Algo ry on Jyväskylän yliopiston tieto- ja ohjelmistotekniikan sekä teknologiajohtamisen opiskelijoiden kilta. Killan tehtävänä on valvoa jäsentensä etuja, järjestää monipuolisia tapahtumia sekä tehdä yhteistyötä alan yritysten kanssa. Ennen kaikkea Algo on jäsenistölleen yhteisö opintojen ajalle."
+      ],
+      "membership": [
+        "Osta Algon jäsenyys \"Liity Jäseneksi\" - nappia painamalla. Seuraa Algoa Instagramissa sekä TikTokissa. Liity myös Algon Discordiin. Nauti Algon eduista ja pidä hauskaa tulevissa tapahtumissa :-). Algon Telegramin viestintäkanaviin liittyminen onnistuu sähköpostista löytyvistä jäsenkirjeistä tai kysymällä hallituslaisilta."
+      ]
+    },
+    "hakijat": {
+      "alt": "Hakijat",
+      "intro": "Hienoa, että olet kiinnostunut opiskelusta Jyväskylän Yliopistossa! Jyväskylän yliopisto tarjoaa kahta eri tutkintoa IT-opiskelijoille:",
+      "degreeProgrammes": "Tieto- ja ohjelmistotekniikka tai Teknologiajohtaminen.",
+      "moreInfoIntro": "Lisätietoja {{degree}} tutkinto-ohjelmasta löydät",
+      "moreInfoLink": "Jyväskylän yliopiston sivuilta.",
+      "aboutTitle": "Mikä ihmeen Algo ry?",
+      "aboutDescription": "Algo ry on Jyväskylän yliopiston tieto- ja ohjelmistotekniikan sekä teknologiajohtamisen opiskelijoiden kilta. Killan tehtävänä on valvoa jäsentensä etuja, järjestää monipuolisia tapahtumia sekä tehdä yhteistyötä alan yritysten kanssa. Ennen kaikkea Algo on jäsenistölleen yhteisö opintojen ajalle.",
+      "tutkinnot": [
+        {
+          "title": "Tieto- ja ohjelmistotekniikka",
+          "ohjelmat": [
+            {
+              "name": "Tekniikan kandidaatti 180op",
+              "opinnot": [
+                "Tieto- ja ohjelmistotekniikan perus- ja aineopinnot 80 op (sis. kandidaatintutkielman)",
+                "Tekniikan alan matemaattiset perusopinnot 35 op",
+                "Toinen opintokokonaisuus (vähintään 25op) – Sivuaine yhdistää tietotekniikan itse valittavaan alaan Jyväskylän yliopiston lukuisista vaihtoehdoista. Voit valita esimerkiksi ihmistieteitä kuten psykologiaa, liikunta- ja terveystieteitä, kulttuuria ja taidetta tai pedagogiikkaa. Vaihtoehtoisesti voit keskittyä vaikkapa matematiikkaan tai luonnontieteisiin.",
+                "Viestintä- ja kieliopintoja vähintään 10 op",
+                "Vapaasti valittavia opintokokonaisuuksia ja moduuleja sekä muita opintoja"
+              ]
+            },
+            {
+              "name": "Diplomi-insinööri 120op",
+              "opinnot": [
+                "Tieto- ja ohjelmistotekniikan syventävät opinnot 80 op (sis. diplomityön)",
+                "Toinen opintokokonaisuus (vähintään 25op) – Sivuaine yhdistää tietotekniikan itse valittavaan alaan Jyväskylän yliopiston lukuisista vaihtoehdoista. Voit valita esimerkiksi ihmistieteitä kuten psykologiaa, liikunta- ja terveystieteitä, kulttuuria ja taidetta tai pedagogiikkaa. Vaihtoehtoisesti voit keskittyä vaikkapa matematiikkaan tai luonnontieteisiin.",
+                "Viestintä- ja kieliopintoja",
+                "Vapaasti valittavia opintokokonaisuuksia ja moduuleja sekä muita opintoja"
+              ]
+            }
+          ],
+          "link": "https://www.jyu.fi/fi/tule-opiskelemaan/tutustu-aloihimme/tekniikka/tieto-ja-ohjelmistotekniikan-opinnot"
+        },
+        {
+          "title": "Teknologiajohtaminen",
+          "ohjelmat": [
+            {
+              "name": "Tekniikan kandidaatti 180op",
+              "opinnot": [
+                "Tieto- ja ohjelmistotekniikan perus- ja aineopinnot 65 op (sis. kandidaatintutkielman)",
+                "Teknologiajohtamisen opintokokonaisuus 40 op",
+                "Tekniikan alan matemaattiset perusopinnot 35 op",
+                "Viestintä- ja kieliopintoja 10 op",
+                "Vapaasti valittavia opintokokonaisuuksia ja moduuleja sekä muita opintoja"
+              ]
+            },
+            {
+              "name": "Diplomi-insinööri 120op",
+              "opinnot": [
+                "Teknologiajohtamisen syventävät opinnot 80 op (sis. Diplomityön)",
+                "Teknologian kaupallistamisen opintoja 25 op",
+                "Viestintä- ja kieliopintoja",
+                "Vapaasti valittavia opintoja ja moduuleja sekä muita opintoja"
+              ]
+            }
+          ],
+          "link": "https://www.jyu.fi/fi/tule-opiskelemaan/tutustu-aloihimme/tekniikka/teknologiajohtamisen-opinnot"
+        }
+      ]
+    },
+    "hallihaku": {
+      "alt": "Board recruitment",
+      "title": "Board recruitment 2027",
+      "description": "Board recruitment for 2027 has started! Here you can get to know the applicants. Instructions for applying to the board can be found in Algo's announcement channel.",
+      "loading": "Ladataan hakemuksia...",
+      "error": "Virhe ladatessa hakemuksia",
+      "chair": "Puheenjohtajisto",
+      "other": "Muut hallituspestit",
+      "emptyChair": "Ei vielä hakemuksia puheenjohtajistoon.",
+      "emptyOther": "Ei vielä hakemuksia muihin hallituspesteihin."
+    },
+    "hallitus": {
+      "loading": "Ladataan...",
+      "error": "Virhe ladattaessa tietoja.",
+      "title": "Hallitus {{year}}",
+      "alt": "Hallitus",
+      "telegram": "Telegram:",
+      "noImage": "Ei kuvaa",
+      "contactIntro": "Psst. mikäli haluat tavoittaa koko hallituksen yhdellä viestillä, voit lähettää sähköpostia osoitteeseen",
+      "contactMembers": "Yksittäisiin hallitusjäseniin saat yhteyden sähköpostitse osoitteilla",
+      "staffTitle": "Toimihenkilöt {{year}}"
+    },
+    "jasenedut": {
+      "title": "Jäsenedut",
+      "intro": "Algo tarjoaa jäsenilleen hienoja etuja! Tsekkaa alta tarkemmin, mihin etuihin Algon jäsenyys sinut oikeuttaa. Jäsenyys todistetaan näyttämällä KideApp-sovelluksesta löytyvä Algon jäsenyys.",
+      "passwords": "Mikäli alennukseen tarvitaan alekoodi, löytyy ne Algon",
+      "secretsLink": "salaisuudet-sivulta",
+      "ask": "Salasanan sivuille voit kysyä hallituslaiselta.",
+      "empty": "Jäsenetuja lisätään pian!"
+    },
+    "international": {
+      "title": "Vaihto-ohjelmat",
+      "erasmusName": "Erasmus (Eurooppa)",
+      "erasmusDescription": "Erasmus tarjoaa 1–2 lukukauden vaihdon EU- ja ETA-maissa sekä Turkissa.",
+      "erasmusLink": "Erasmus-ohjelma",
+      "bilateralName": "Kahdenväliset kohteet",
+      "bilateralDescription": "Vaihdot Euroopan ulkopuolelle kuten Amerikkaan ja Aasiaan.",
+      "isepName": "ISEP",
+      "isepDescription": "Yksi hakemus useisiin yliopistoihin ympäri maailmaa.",
+      "northName": "Nordplus",
+      "northDescription": "Mahdollistaa vaihdon Pohjoismaihin ja Baltiaan.",
+      "forthemName": "FORTHEM",
+      "forthemDescription": "Tarjoaa lyhytliikkuvuuksia ja Erasmus-vaihtoja allianssin sisällä."
+    },
+    "events": {
+      "empty": "Tapahtumia lisätään pian!"
+    },
+    "home": {
+      "introText": "Algo ry on vuonna 2022 perustettu kilta, joka yhdistää Jyväskylän yliopiston tieto- ja ohjelmistotekniikan sekä teknologiajohtamisen opiskelijat.",
+      "upcomingEvents": "TULEVAT TAPAHTUMAT",
+      "diamondPartners": "TIMANTTIKUMPPANIT"
+    },    "saannot": {
+      "title": "Algo ry:n säännöt",
+      "alt": "Säännöt",
+      "sections": [
+        {
+          "title": "1. Yhdistyksen nimi ja kotipaikka",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistyksen nimi on Algo ry ja sen kotipaikka on Jyväskylä."
+            }
+          ]
+        },
+        {
+          "title": "2. Tarkoitus ja toiminnan laatu",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistyksen tarkoituksena on toimia Jyväskylän yliopiston tieto- ja ohjelmistotekniikan ja teknologiajohtamisen opiskelijoiden yhdyssiteenä informaatioteknologian tiedekuntaan, edistää heidän opintojaan, harrastuksiaan ja yhteisiä etujaan sekä huolehtia jäsentensä oikeuksista opiskelijoina."
+            },
+            {
+              "type": "heading",
+              "text": "Tarkoituksensa toteuttamiseksi yhdistys:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "voi järjestää kursseja, harjoitus- ja opetustilaisuuksia sekä muuta vastaavaa toimintaa",
+                "voi järjestää kilpailuja, näytöksiä, retkiä, leirejä ja muita tapahtumia",
+                "voi järjestää juhlia, konsertteja, näyttelyitä tai muita tilaisuuksia",
+                "voi ylläpitää yhdistyksen sähköisiä viestintäkanavia",
+                "voi julkaista yhdistyksen tiedotteita ja muuta viestintää eri viestintäkanavissa",
+                "neuvoo ja ohjaa jäseniään",
+                "voi kerätä ja jakaa tietoa sekä harjoittaa tutkimustoimintaa",
+                "kokoaa jäsenet yhteiseen toimintaan ja ylläpitää yhteyksiä muihin alan yhdistyksiin",
+                "ylläpitää jäsenistään koostuvaa esiintyvää ryhmää",
+                "voi järjestää yhdistyksen tarkoitukseen liittyviä matkoja jäsenilleen",
+                "voi osallistua jäsentensä välittömiin kilpailukustannuksiin",
+                "voi hankkia tarvittavia aineistoja ja välineitä yhdistyksen käyttöön",
+                "pyrkii järjestämään käyttöönsä tilat, joita yhdistyksen jäsenet voivat käyttää",
+                "voi tehdä esityksiä ja aloitteita harrastusmahdollisuuksien lisäämiseksi",
+                "toimii yhteistyössä viranomaisten, järjestöjen, yritysten ja yksityishenkilöiden kanssa"
+              ]
+            },
+            {
+              "type": "heading",
+              "text": "Toimintansa tukemiseksi yhdistys voi, hankittuaan tarvittaessa asianomaisen luvan:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "järjestää rahankeräyksiä ja arpajaisia",
+                "järjestää myyjäisiä, kirpputori- ja muita tapahtumia",
+                "järjestää maksullisia tilaisuuksia",
+                "ottaa vastaan avustuksia, lahjoituksia ja testamentteja",
+                "omistaa toimintansa kannalta tarpeellista irtainta ja kiinteää omaisuutta",
+                "harjoittaa kahvilatoimintaa",
+                "harjoittaa anniskelutoimintaa järjestämiensä tilaisuuksien yhteydessä",
+                "tehdä talkootyötä",
+                "myydä mainostilaa",
+                "solmia sponsorisopimuksia"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "3. Jäsenet",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistykseen varsinaiseksi jäseneksi voidaan hyväksyä henkilö, joka on Jyväskylän yliopistossa tieto- ja ohjelmistotekniikan tai teknologiajohtamisen opintoja suorittava perus- tai jatko-opiskelija tai henkilö, jonka yhdistyksen hallituksen kokous muuten hyväksyy jäseneksi. Kannattavaksi jäseneksi voidaan hyväksyä yksityinen henkilö tai oikeuskelpoinen yhteisö, joka haluaa tukea yhdistyksen tarkoitusta ja toimintaa. Varsinaiset jäsenet ja kannattavat jäsenet hyväksyy hakemuksesta yhdistyksen hallitus. Jäsenistä pidetään jäsenrekisteriä. Jäsen on velvollinen ilmoittamaan yhdistyksen hallitukselle, mikäli hänen yhteystietonsa muuttuvat. Kunniajäsenekseen yhdistys voi hallituksen esityksestä kutsua yhdistyksen toimintaa ansiokkaasti tukeneen henkilön, joka on antanut siihen suostumuksensa. Kunniajäsen voidaan nimittää joko hallituksen kokouksessa yksimielisellä äänestyksellä koko hallituksen ollessa paikalla tai yhdistyksen kokouksessa äänienemmistöllä. Kunniajäsenyys on elinikäinen. Saavutetut jäsenoikeudet säilyvät."
+            },
+            {
+              "type": "paragraph",
+              "text": "Varsinaisten jäsenten jäsenmaksu maksetaan kahdeksan (8) vuoden välein. Jäsenen tulee erota tai hänet voidaan hallituksen päätöksellä erottaa, kun hänen opintonsa IT-tiedekunnassa päättyvät. Jäsen voidaan katsoa eronneeksi, mikäli hän ei ole maksanut jäsenmaksuaan 1 kuukauden kuluessa uuden jäsenmaksukauden alkamisen jälkeen. Jäsen voidaan erottaa yhdistyksen jäsenyydestä, jos jäsen on laiminlyönyt jäsenmaksun maksamisen, jos jäsen ei ole enää jäsenyyskriteerien perusteella jäsenkelpoinen tai jos jäsen on toiminnallaan aiheuttanut merkittävää haittaa yhdistykselle tai sen maineelle. Jäsenen erottamisesta päättää yhdistyksen hallitus enemmistö äänillä. Jäsenellä on oikeus erota yhdistyksestä ilmoittamalla siitä kirjallisesti hallitukselle tai sen puheenjohtajalle tai ilmoittamalla erosta yhdistyksen kokouksessa merkittäväksi pöytäkirjaan."
+            }
+          ]
+        },
+        {
+          "title": "4. Liittymis- ja jäsenmaksu",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Varsinaisilta jäseniltä ja kannattavilta jäseniltä perittävän liittymismaksun ja vuotuisen jäsenmaksun suuruudesta erikseen kummallekin jäsenryhmälle päättää kevätkokous. Kunniajäsenet eivät suorita jäsenmaksuja."
+            },
+            {
+              "type": "paragraph",
+              "text": "Liittymis- ja jäsenmaksun keräämiskausi on 1.9.–31.8."
+            }
+          ]
+        },
+        {
+          "title": "5. Hallitus",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistyksen asioita hoitaa hallitus, johon kuuluu syyskokouksessa valittu puheenjohtaja, varapuheenjohtaja, sihteeri, rahastonhoitaja ja enintään kaksikymmentä (20) muuta varsinaista jäsentä. Puheenjohtaja, varapuheenjohtaja, sihteeri, rahastonhoitaja ja mahdolliset muut hallituksen jäsenet valitaan ehdottomalla äänten enemmistöllä. Jos ehdokkaita yhteen pestiin on useampi kuin kaksi (2), eikä kukaan saa ensimmäisellä kierroksella enempää kuin puolet annetuista äänistä, käydään toinen kierros ensimmäisellä kierroksella kahden eniten ääniä saaneen kesken. Lopullisessa äänestyksessä äänten mennessä tasan ratkaisee arpa."
+            },
+            {
+              "type": "paragraph",
+              "text": "Hallituksen toimikausi on kalenterivuosi. Hallitus kokoontuu puheenjohtajan tai hänen estyneenä ollessaan varapuheenjohtajan kutsusta, kun he katsovat siihen olevan aihetta tai kun vähintään puolet hallituksen jäsenistä sitä vaatii. Hallitus on päätösvaltainen, kun vähintään puolet sen jäsenistä, puheenjohtaja tai varapuheenjohtaja mukaan luettuna on läsnä. Äänestykset ratkaistaan ehdottomalla äänienemmistöllä. Äänten mennessä tasan ratkaisee kokouksen puheenjohtajan ääni, vaaleissa kuitenkin arpa."
+            },
+            {
+              "type": "paragraph",
+              "text": "Hallituksen jäsenen erotessa kesken toimikauden eronneen jäsenen tilalle voidaan valita uusi jäsen. Uuden jäsenen toimikausi kestää siihen asti kuin eronneen toimikausi olisi kestänyt."
+            },
+            {
+              "type": "paragraph",
+              "text": "Kaikilla jäsenillä on oikeus osallistua hallituksen kokouksiin ilman äänivaltaa."
+            }
+          ]
+        },
+        {
+          "title": "6. Yhdistyksen nimen kirjoittaminen",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistyksen nimen kirjoittavat hallituksen puheenjohtaja ja varapuheenjohtaja kaksin, tai yritysvastaava yhdessä puheenjohtajan tai varapuheenjohtajan kanssa."
+            }
+          ]
+        },
+        {
+          "title": "7. Tilikausi",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistyksen tilikausi on kalenterivuosi. Tilinpäätös tarvittavine asiakirjoineen ja hallituksen vuosikertomus on annettava toiminnantarkastajalle viimeistään kolme viikkoa ennen kevätkokousta. Toiminnantarkastajan tulee antaa kirjallinen lausuntonsa viimeistään viikko ennen kevätkokousta hallitukselle."
+            }
+          ]
+        },
+        {
+          "title": "8. Yhdistyksen kokoukset",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Yhdistys pitää vuosittain kaksi varsinaista kokousta. Yhdistyksen kevätkokous pidetään tammi-toukokuussa ja syyskokous syys-joulukuussa hallituksen määräämänä päivänä. Yhdistyksen kokouksissa jokaisella varsinaisella jäsenellä on yksi ääni. Kannattavalla jäsenellä ja kunniajäsenellä on kokouksessa läsnäolo- ja puheoikeus."
+            },
+            {
+              "type": "paragraph",
+              "text": "Yhdistyksen kokouksen päätökseksi tulee, ellei säännöissä ole toisin määrätty, se mielipide, jota on kannattanut yli puolet annetuista äänistä. Äänten mennessä tasan ratkaisee kokouksen puheenjohtajan ääni, vaaleissa kuitenkin arpa. Kokous on päätösvaltainen, kun se on laillisesti koolle kutsuttu. Yhdistyksen kokoukseen voidaan osallistua hallituksen tai yhdistyksen kokouksen niin päättäessä myös postitse, tietoliikenneyhteyden tai muun teknisen apuvälineen avulla kokouksen aikana tai ennen kokousta."
+            }
+          ]
+        },
+        {
+          "title": "9. Yhdistyksen kokousten koollekutsuminen",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Hallituksen on kutsuttava yhdistyksen kokoukset koolle vähintään seitsemän vuorokautta ennen kokousta sähköpostitse jäsenen ilmoittamaan osoitteeseen sekä jäsenille tarkoitetulla some-kanavalla."
+            }
+          ]
+        },
+        {
+          "title": "10. Varsinaiset kokoukset",
+          "content": [
+            {
+              "type": "heading",
+              "text": "Yhdistyksen kevätkokouksessa käsitellään seuraavat asiat:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "esitetään tilinpäätös ja toiminnantarkastajien/tilintarkastajien lausunto",
+                "päätetään tilinpäätöksen vahvistamisesta ja vastuuvapauden myöntämisestä hallitukselle ja muille vastuuvelvollisille",
+                "vahvistetaan liittymis- ja jäsenmaksujen suuruudet seuraavalle keräämiskaudelle (määritelty sääntöjen kohdassa 4. “Liittymis- ja jäsenmaksu”)"
+              ]
+            },
+            {
+              "type": "heading",
+              "text": "Yhdistyksen syyskokouksessa käsitellään seuraavat asiat:"
+            },
+            {
+              "type": "list",
+              "items": [
+                "vahvistetaan toimintasuunnitelma, tulo- ja menoarvio",
+                "valitaan hallituksen puheenjohtaja ja muut jäsenet",
+                "valitaan yksi tai kaksi toiminnantarkastajaa ja varatoiminnantarkastajaa"
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Mikäli yhdistyksen jäsen haluaa saada jonkin asian yhdistyksen kevät- tai syyskokouksen käsiteltäväksi, on hänen ilmoitettava siitä kirjallisesti hallitukselle niin hyvissä ajoin, että asia voidaan sisällyttää kokouskutsuun."
+            }
+          ]
+        },
+        {
+          "title": "11. Sääntöjen muuttaminen ja yhdistyksen purkaminen",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Päätös sääntöjen muuttamisesta ja yhdistyksen purkamisesta on tehtävä yhdistyksen kokouksessa vähintään kolmen neljäsosan (3/4) enemmistöllä annetuista äänistä. Kokouskutsussa on mainittava sääntöjen muuttamisesta tai yhdistyksen purkamisesta. Yhdistyksen purkautuessa annetaan yhdistyksen varat kokouksen päättämään hyväntekeväisyyskohteeseen. Yhdistyksen tullessa lakkautetuksi käytetään sen varat samaan tarkoitukseen."
+            }
+          ]
+        }
+      ]
+    },
+    "vuju": {
+      "title": "Vuosijuhlaetiketti",
+      "alt": "Vuosijuhlat",
+      "intro": "Algo täyttää virallisesti vuosia heinäkuun 4. päivä, mutta sen vuosijuhlaa juhlitaan perinteisesti syksyn puolella. Vuosijuhla on kiltamme arvokkain akateeminen tilaisuus, jossa käyttäydytään sen mukaisesti. Juhlaan ovat tervetulleita niin Algon jäsenet, kutsuvieraat kuin avecitkin. Tämä etiketti tutustuttaa juhlavieraat vuosijuhlien käytänteisiin, jotta itse juhlassa ei tarvitsisi hermoilla käytännön asioista.",
+      "sections": [
+        {
+          "heading": "Pukeutuminen",
+          "text": "Vuosijuhlilla pukeudutaan joko frakkiin, tummaan pukuun tai iltapukuun.\n\n**Frakkiin** kuuluu musta hännystakki ja housut, valkoinen frakkiliivi, valkoinen frakkipaita helmiäisnapeilla sekä valkoinen solmuke. Frakin kanssa käytetään mustia sukkia ja mustia kiiltonahkakenkiä. Rannekelloa ei suositella käytettäväksi frakin kanssa. Smokki tai muut variaatiot eivät ole etiketin mukainen vaihtoehto frakille.\n\n**Tumma puku** tarkoittaa tumman harmaata, tumman sinistä tai mustaa pukua. Puku voi olla yksivärinen tai hillitysti raidallinen, mutta ei liituraitaa. Tumman puvun kanssa käytetään valkoista tai vaaleanpunaista paitaa (muutkin vaaleat värit käyvät mainiosti), juhlavaa solmiota tai solmuketta, mustia kenkiä sekä tummia ja pitkävartisia sukkia.\n\n**Iltapuku** on juhlavasta materiaalista valmistettu nilkka- tai lattiapituinen il­ta­- tai juh­la­pu­ku. Iltapuku voi olla avonainen, umpinainen, olkaimeton tai pitkähihainen. Iltapuvun kanssa voi käyttää myös har­ti­a­hui­vi­a, kyynärmittaisia hansikkaita tai ol­kai­me­ton­ta lauk­ku­a. Ruokailun aikana ei ole soveliasta laskea käsilaukkua pöydälle tai pitää hanskoja käsissään.\n\nPukeutumista voi täydentää akateemisilla ansiomerkeillä ja juhlanauhalla. Juhlanauha- ja merkkiohjesääntöjen pykälän 10 mukaan:\n\n*“Juhlanauhaa sekä kunnia-, ansio- ja hallitusmerkkiä käytetään vain juhlapuvussa akateemisissa juhlatilaisuuksissa. Juhlanauhaa kannetaan siten, että se kulkee oikealta olkapäältä rinnan yli vasemmalle lantiolle, vaaleanpunainen väri yläpuolella. Juhlanauhaa kannetaan juhlapuvussa liivin alla ja tummassa puvussa liivin ja solmion päällä. Mekon kanssa juhlanauhaa voi kantaa taiteltuna ruusukkeena vasemmalla puolella rintaa, vaaleanpunainen väri päällimmäisenä, tai kuten juhlapuvussa. Juhlanauha ei saa koskettaa paljasta ihoa.”*\n\n*Algo ry:n omissa tilaisuuksissa juhlanauhaa kannetaan ylimpänä, jos kantajalla on myös muiden organisaatioiden nauhoja. Muissa tilaisuuksissa noudatetaan soveltuvia ohjesääntöjä.*\n\n*Kunnia-, ansio- ja hallitusmerkkejä voi käyttää samanaikaisesti juhlanauhan kanssa, eikä niiden asettelulla ole väliä.*"
+        },
+        {
+          "heading": "Arvokas juhlakäyttäytyminen",
+          "text": "Vuosijuhla on ennen kaikkea akateeminen pöytäjuhla, jossa kunnolliset pöytätavat ovat vaatimus. Juhlaan on tehty istumajärjestys eli jokaisen paikka on merkitty nimikortilla. Jos omassa pöydässä on ihmisiä, joita et tunne entuudestaan, on kohteliasta aluksi esittäytyä, ja pitää puhetta yllä myös muiden kuin tuttujen kanssa koko tilaisuuden ajan.\n\nJuhlan kulusta vastaavat seremoniamestarit, joita tulee kuunnella. Myös puheiden, laulujen ja muun ohjelman aikana on oltava hiljaa ja syömättä. Seurustelulle on varattu paljon aikaa, joten puhumaan kyllä ehtii. Kunnianosoitukset puheille ja muulle ohjelmalle esitetään taputtamalla käsiä.\n\nSkoolatessa eli lasia kohotettaessa katsotaan ensin pöydän toisella puolella vasemmalla istuvaa, sitten pöydän toisella puolella oikealla istuvaa ja viimeiseksi itseään vastapäätä istuvaa henkilöä. Kohotettaessa lasit eivät kosketa toisiaan vaan kilistelyn korvaa pieni nyökkäys.\n\nTauoille saa poistua vain ohjelmaan merkittyjen taukojen aikana. Jos omalta paikalta poistumiseen tulee kuitenkin pakottava tarve muulloin, on poistuminen tehtävä huomiota herättämättä ja pöytäseurueelle pahoitellen eikä missään nimessä puheiden tai esitysten aikana.\n\nJuhlasta ei ole soveliasta myöhästyä, joten saavuthan ajoissa juhlapaikalle."
+        },
+        {
+          "heading": "Juhlan kulku",
+          "text": "Juhla alkaa perinteisesti cocktail-tilaisuudella eli kokkareilla. Tähän tilaisuuteen osallistuvat vain kutsuvieraat eli vieraat, jotka ovat saaneet erillisen kutsun juhliin. Tällaisia vieraita ovat muun muassa killan kunniajäsenet, opettajat tai muiden kiltojen tai ainejärjestöjen edustajat. Kokkareilla kutsuvieraat pitävät vuorotellen onnittelupuheita vuosia täyttävälle Algolle ja antavat lahjoja. Tarjolla on yleensä kuohuvaa ja pientä purtavaa. Tilaisuus on yleensä seisomatilaisuus, ja se kestää noin pari tuntia.\n\nCocktail-tilaisuudesta siirrytään suoraan pääjuhlaan. Pääjuhlaan osallistuvat kaikki, jotka ovat ostaneet lipun vuosijuhliin. Juhla alkaa, kun lippuairue tuo Suomen lipun juhlasaliin. Tällöinjuhlavieraat nousevat seisomaan ja odottavat hiljaisuudessa lipun paikalleen viemistä, jonka jälkeen lauletaan yhteisesti Finlandia. Tässä vaiheessa seremoniamestarit esittäytyvät ja jakavat yleisiä ohjeita. Sen jälkeen lauletaan Helan Går, jonka yhteydessä nautitaan alkushotti. Laulujen jälkeen raikuvat tervetuliaissanat ja juhla voi alkaa.\n\nAlkupuheiden jälkeen aloitetaan seurustelu ja laulaminen. Lauluja jacpuheenvuoroja voi toivoa kilistämällä omaa lasiaan. Yleensä laulutctoivotaan omalle istumapaikalle jaetusta lauluvihosta. Pääruoan ajaksi julistetaan ruokarauha, jonka aikana lauluja saa kyllä toivoa, mutta poikkeuksellisesti saa myös syödä laulujen aikana. Ei ole kuitenkaan soveliasta laulaa ruoka suussa. Ruokailua ennen ja sen jälkeen on kaikennäköistä ohjelmaa: puheita palkitsemisia, esityksiä, laulamista. Juhlan loppupuolella syödään jälkiruokaa, jonka kanssa nautitaan kahvia yleensä avecin kera. Tässä yhteydessä avec voi tarkoittaa esim. konjakkia tai likööriä. Jälkiruoan aikana kohotetaan Jallu-shotti, ja lauletaan Jallutähden alla. Juhla päättyy puheenjohtajan sanoihin ja Suomen lipun uloskantoon.\n\nCocktail-tilaisuudessa ja pääjuhlassa on yleensä kuvaaja, joka ottaa kuvia niin kuvausseinän edessä kuin itse juhlassakin. Kuvat jaetaan vieraille jälkikäteen juhlien järjestäjien valitsemalla tavalla.\n\nPääjuhlan loppuessa meno ei lannistu, vaan juhlimista jatketaan virallisilla jatkoilla. Vuosijuhlilla saattaa olla tarjolla drinkkilippuja ja narikka on yleensä etukäteen maksettu, mikä sujuvoittaa jatkoille siirtymistä. Keskiyöllä juhlaväki kokoontuu pimennettyyn tilaan laulamaan teekkarihymnin."
+        },
+        {
+          "heading": "Akateeminen silliaamiainen",
+          "text": "Vuosijuhlista palautuminen tapahtuu silliaamiaisella eli silliksellä, joka järjestetään vuosijuhlien jälkeisenä päivänä. Se järjestetään jossain rennossa paikassa, kuten esimerkiksi Opinkiven saunalla. Silliksellä on yleensä tarjolla rasvaista ruokaa ja virvokkeita, ja pukukoodina toimivat haalarit."
+        }
+      ]
+    },
+    "kunniagalleria": {
+      "alt": "Kunniagalleria",
+      "honoraryTitle": "Algo ry:n kunniajäsenet",
+      "honoraryDescription": "Kunniajäsen on killan toimintaa erityisen ansiokkaasti tukenut henkilö. Kunniajäsenyys on Algon korkein kunnianosoitus.",
+      "yearlyTitle": "Vuoden Algolainen -palkinnon voittajat",
+      "yearlyDescription": "Vuoden algolainen on jäsenten äänestyksessä päättämä, joka on osoittanut merkittävää kiinnostusta yhdistyksen toimintaa kohtaan ja edistänyt jäsenten välistä yhteishenkeä.",
+      "previousBoards": "Muut edelliset hallitukset näet",
+      "here": "täältä"
+    },    "aktiivit": {
+      "alt": "Aktiivit",
+      "title": "MIKÄ IHMEEN AKTIIVI???",
+      "description": "Aktiivit koostuvat kiltamme jäsenistä, jotka haluavat auttaa ja vaikuttaa kiltamme toimintaan. Aktiivit auttavat hallituksemme jäseniä matalalla kynnyksellä.",
+      "rolesTitle": "AKTIIVIEN PESTIT",
+      "interestedTitle": "Kiinnostuitko?",
+      "interestedDescription": "Hae aktiiviksi täyttämällä alla olevan lomakkeen!",
+      "applyButton": "Hae Aktiiviksi",
+      "badgesTitle": "Aktiivimerkit",
+      "teams": [
+        {
+          "title": "Tapahtumatiimi",
+          "tasks": [
+            {
+              "title": "Tapahtumien suunnittelu ja järjestäminen",
+              "subTasks": [
+                "Sisältää esimerkiksi tapahtumapaikan varaamista ja järjestelemistä sekä yleistä tapahtuman suunnittelua"
+              ]
+            },
+            { "title": "Tapahtumamerkkien suunnittelu" },
+            { "title": "Liikuntatapahtumien järjestäminen" },
+            { "title": "Tapahtumatiimiä ylläpitää" }
+          ],
+          "responsibles": [
+            { "nimi": "Tapahtumavastaava(t)", "href": "/hallitus" }
+          ]
+        },
+        {
+          "title": "Yritysyhteistyötiimi",
+          "tasks": [
+            {
+              "title": "Yritysyhteistöiden kontaktointi ja hankinta",
+              "subTasks": [
+                "Myös esimerkiksi pienten kertaluontoisten sponsoreiden hankinta"
+              ]
+            },
+            { "title": "Yritysyhteistyötiimiä ylläpitää" }
+          ],
+          "responsibles": [
+            { "nimi": "Yrityssuhdevastaava", "href": "/hallitus" }
+          ]
+        },
+        {
+          "title": "Some- ja viestintätiimi",
+          "tasks": [
+            {
+              "title": "Somekanavien ylläpito",
+              "subTasks": ["Instagram & TikTok"]
+            },
+            { "title": "Tapahtumien kuvaaminen" },
+            { "title": "Killan mainostaminen" },
+            { "title": "Killan jäsenviestintä sähköpostitse" },
+            { "title": "Some- ja viestintätiimiä ylläpitää" }
+          ],
+          "responsibles": [
+            { "nimi": "Viestintävastaava", "href": "/hallitus" }
+          ]
+        }
+      ],
+      "other": [
+        { "title": "Yhdenvertaisuus-vastaava tapahtumissa" },
+        {
+          "title": "Juhlatiimi",
+          "subTasks": ["Vapun ja vuosijuhlien järjestäminen"]
+        },
+        {
+          "title": "Nettimestari",
+          "subTasks": [
+            "Nettisivujen päivitys ja ylläpito",
+            "Alidomainien sovellusten ylläpito",
+            "Palvelimen ylläpito"
+          ]
+        },
+        {
+          "title": "Lisätietoja eri aktiivitehtävistä voi kysyä hallituksen jäseneltä"
+        }
+      ]
+    },
+    "kerhotoiminta": {
+      "title": "Kerhotoiminta",
+      "intro": "Kerhotoiminta on jäsenistön itsensä organisoimaa tekemistä, joka voi liittyä esimerkiksi harrastuksiin, yhteisöllisyyteen tai opiskelun tukemiseen. Kaikki jäsenet voivat osallistua kerhoihin tai olla mukana niiden perustamisessa.",
+      "sectionTitle": "Algon kerhot",
+      "infoPrefix": "Lisätietoja kerhosta sekä peliaikatauluista saat liittymällä kerhon Telegram-ryhmään:",
+      "kerhot": {
+        "kyykkä": {
+          "name": "Kyykkäkerho",
+          "description": "Kyykkäkerho tarjoaa mahdollisuuden tutustua kyykkään hauskassa ja yhteisöllisessä hengessä. Toiminta on avointa kaikille jäsenille taitotasosta riippumatta.",
+          "linkText": "Kyykätään!",
+          "linkHref": "https://t.me/+0nivuYqDLzUxYjNk"
+        },
+        "futis": {
+          "name": "Futiskerho",
+          "description": "Algo FC tarjoaa mahdollisuuden pelata jalkapalloa rennossa ja yhteisöllisessä hengessä. Toiminta on avointa kaikille jäsenille taitotasosta riippumatta – mukaan voi tulla niin ensikertalainen kuin kokenutkin peluri. ⚽",
+          "linkText": "Pelaamaan!",
+          "linkHref": "https://t.me/+IhWC1RJ9ZGM0OGU0"
+        }
+      },
+      "newClub": {
+        "title": "Haluatko perustaa uuden kerhon?",
+        "description": "Uuden kerhon perustaminen onnistuu seuraavilla askelilla:",
+        "steps": [
+          {
+            "title": "Laadi alustava toimintasuunnitelma",
+            "points": [
+              "Mihin aiheeseen tai tekemiseen kerho liittyy",
+              "Kerhon tarkoitus ja kohderyhmä",
+              "Millaisia tapahtumia, tapaamisia tai muuta toimintaa on suunnitteilla",
+              "Millaisia hyötyjä kerho tuo jäsenistölle ja mitä tavoitteita sillä on"
+            ]
+          },
+          {
+            "title": "Ota yhteyttä hallituksen puheenjohtajaan ja sovi tapaaminen, jossa ideoita voidaan yhdessä tarkastella ja kehittää."
+          },
+          {
+            "title": "Jos kerholle nähdään selkeä tarve ja potentiaalia, valmistele täydennetty toimintasuunnitelma hallituksen kokousta varten."
+          },
+          {
+            "title": "Hallitus tekee päätöksen kerhon perustamisesta kokouksessaan."
+          }
+        ]
+      },
+      "support": {
+        "title": "Mitä tukea kerhot saavat?",
+        "description": "Hyväksytyt kerhot toimivat virallisesti yhdistyksen alaisuudessa ja voivat saada tukea esimerkiksi seuraavilla tavoilla:",
+        "points": [
+          "Toimintaan liittyvien kustannusten korvaaminen",
+          "Algon viestintäkanavien käyttö (esim. telegram ja uutiskirjeet)",
+          "Mahdollisuus pyytää muuta tukea tilanteen mukaan – ole rohkeasti yhteydessä kerhovastaavaan!"
+        ]
+      }
+    },
+    "ohjesaannot": {
+      "intro": "Tältä sivulta löydät tietoa teekkarilakista, haalarietiketistä sekä juhlanauha- ja merkkiohjesäännöstä.",
+      "title": "Juhlanauha- ja merkkiohjesääntö",
+      "rules": [
+        "1§ Algo ry:llä on kunnia-, ansio-, hallitus- ja vuoden algolainen -merkki sekä juhlanauha, joista jäljempänä lähemmin määrätään. Merkkien mallikappaleet säilytetään yhdistyksen arkistossa, ja myönnetyistä sekä ohjesäännön mukaan jaetuista merkeistä, niiden myöntämisperusteista ja päivämääristä pidetään luetteloa.",
+        "2§ Merkkien antamisesta päättää yhdistyksen hallitus. Hallitus voi jakaa useamman merkin kuin mitä tämän ohjesäännön enimmäismäärä sallii, mikäli hallitus päättää siitä yksimielisesti. Ellei päätösehdotusta hyväksytä, ei asian käsittelystä tehdä merkintää pöytäkirjaan.",
+        "3§ Kunniajäsenekseen yhdistys voi hallituksen esityksestä kutsua yhdistyksen toimintaa ansiokkaasti tukeneen henkilön, joka on antanut siihen suostumuksensa. Kunniajäsenelle myönnetään kunniakirja, joka on varustettu istuvan puheenjohtajan nimikirjoituksella, ja hänet kutsutaan yhdistyksen vuosijuhliin joka vuosi, mikäli sellaiset järjestetään. Kunniajäsenyys on elinikäinen.",
+        "4§ Kunniamerkki voidaan antaa henkilölle, joka pitkäaikaisella toiminnallaan tai erittäin merkittävällä teollaan on huomattavasti edistänyt yhdistyksen toimintaa. Kunniamerkki myönnetään myös jokaiselle kunniajäsenelle joko kunniajäseneksi myöntämisen yhteydessä tai takautuvasti. Kunniamerkkejä voidaan vuosittain myöntää enintään kolme (3) kappaletta. Kunniamerkki on väriltään kultainen ja kooltaan xx mm.",
+        "5§ Ansiomerkki voidaan antaa henkilölle, joka on viimeisen vuoden aikana edistänyt ansiokkaasti yhdistyksen toimintaa. Ansiomerkkejä voidaan vuosittain myöntää enintään viisi (5) kappaletta. Ansiomerkki on väriltään hopeinen ja kooltaan xx mm.",
+        "6§ Hallitusmerkki myönnetään yhdistyksen istuvan hallituksen jäsenille. Hallitusmerkki voidaan myöntää myös yhdistyksen hallituksen entiselle jäsenelle. Hallitusmerkki on väriltään hopeinen ja kooltaan 16 mm.",
+        "7§ Vuoden algolainen -merkki myönnetään Algo ry:n jäsenelle, joka on osoittanut merkittävää kiinnostusta yhdistyksen toimintaa kohtaan ja edistänyt jäsenten välistä yhteishenkeä. Jäsen valitaan vuosittain järjestettävällä äänestyksellä, jossa jokaisella Algo ry:n jäsenellä on äänioikeus. Äänestyksestä tiedotetaan yhdistyksen virallisilla viestintäkanavilla viimeistään 2 viikkoa ennen merkinjakotilaisuutta. Yksittäinen henkilö voi saada merkin vain kerran. Vuoden algolainen -merkki on haalarimerkki, joka on halkaisijaltaan 80 mm ja väriltään violetti keltaisella pokaalilla.",
+        "8§ Myönnetyt merkit ja kunniakirjat luovutetaan saajilleen seuraavissa yhdistyksen vuosijuhlissa, vuosijuhlasitseillä tai muussa hallituksen sopivaksi katsomassa arvokkaassa tilaisuudessa. Kaikkien Algo ry:n myöntämien merkkien käyttöoikeus on elinikäinen.",
+        "9§ Juhlanauha on 35 mm leveä ja väriltään vaaleapuna-valkoinen. Jokaisella yhdistyksen varsinaisella jäsenellä on nauhan käyttöoikeus, ja nauhan voi ostaa suoraan yhdistykseltä. Juhlanauha myönnetään ansiomerkin mukana ilmaiseksi, mikäli ansioituvalla henkilöllä ei sellaista vielä ole. Juhlanauhan käyttöoikeus säilyy yhdistyksestä eroamisen jälkeen.",
+        "10§ Juhlanauhaa sekä kunnia-, ansio- ja hallitusmerkkiä käytetään vain juhlapuvussa akateemisissa juhlatilaisuuksissa.",
+        "11§ Tämä ohjesääntö on hyväksytty yhdistyksen kokouksessa 26.5.2023. Se on voimassa toistaiseksi. Tämän ohjesäännön muuttamisesta päättää yhdistyksen kokous ehdottomalla äänienemmistöllä."
+      ],
+      "haalarietiketti": {
+        "title": "Haalarietiketti",
+        "paragraphs": [
+          "Haalareita suositellaan pidettävän ylhäällä eli kokonaan päällä. Niitä käytetään kaikissa opiskelijatapahtumissa, ellei tapahtuman pukeutumisesta erikseen toisin mainita. Kun haalareita pidetään vyötäröllä, selkäosa taitetaan siten, että killan logo näkyy. Haalareita saa ja tulee muokata oman näköisiksi.",
+          "Haalarimerkit tulee ommella käsin. Niitä ei saa liimata eikä ommella ompelukoneella. Lisäksi haalarimerkkejä ei tule ommella sponsoreiden logojen päälle, mikäli tilaa on.",
+          "Haalareita ei saa pestä pesukoneessa tai muulla vastaavalla tavoin. Haalareita pestään siten, että olet itse niiden sisällä, esimerkiksi järvessä tai suihkussa."
+        ]
+      },
+      "teekkari": {
+        "title": "Teekkarilakki",
+        "imageAlt": "Jyväskylän 8-kulmainen teekkarilakki",
+        "description": "Jyväskylän teekkarilakki on kahdeksankulmainen, Jyväskylän kävelykadun Kompassin muodon mukaan. Lakin sisäpuoli on Jyväskylän yliopiston värien mukainen sini-oranssi. Lakin kokardissa yhdistyy Jyväskylä sekä tekniikka, kun kokardista löytyy JYY:n soihtu, jota ympäröi tekniikan ratas. Ensimmäisen vuoden diplomi-insinööriopiskelijoista eli fukseista tulee teekkareita vappuna, jolloin kasteen jälkeen lakin saa painaa päähänsä. Lakin kantoaika alkaa siis vapun kasteesta ja päättyy syyskuun viimeisenä päivänä pidettäviin lakinlaskijaisiin.",
+        "linkText": "Jyväskylän teekkariyhdistys",
+        "linkText2": "lakinkäyttölupaa"
+      }
+    },
+    "periaatteet": {
+      "title": "Toiminnasta",
+      "intro": "Algon killan sisällä apua voi hakea sopolta/kopolta (sopo@algojkl.com & kopo@algojkl.com) tai anonyymisti lomakkeella, jonka löydät",
+      "formLink": "täältä",
+      "support": "Lomakkeen vastaukset näkyvät vain sopolle/kopolle.",
+      "summaryTitle": "Toiminnasta:",
+      "summary": "Algo ei hyväksy minkäänlaista syrjintää tai häirintää omassa toiminnassaan ja pyrimme rakentamaan kannustavaa ilmapiiriä. Jos kohtaat väärinkäytöksiä, häirintää, syrjintää tai koet olosi turvattomaksi, kerro asiasta ja pyydä apua. Tukea ja apua on aina saatavilla jos koet sitä tarvitsevasi.",
+      "valuesTitle": "Algo ja sen jäsenet sitoutuvat noudattamaan seuraavia arvoja:",
+      "values": [
+        "Kaikki ihmiset ovat samanarvoisia riippumatta heidän sukupuolestaan, iästään, etnisestä tai kansallisesta alkuperästään, kansalaisuudestaan, kielestään, uskonnostaan, seksuaalisesta suuntautumisestaan tai muusta henkilöön liittyvästä syystä",
+        "Ei painostateta päihteiden käyttöön.",
+        "Noudatetaan hyviä käytöstapoja ja käyttäydytään asiallisesti.",
+        "Ymmärretään ja kunnioitetaan erilaisia näkökulmia.",
+        "Ylläpidetään, luodaan ja kehitetään tervettä Teekkarihenkeä.",
+        "Jokainen nauttii opiskeluajastansa omilla ehdoillaan sekä edellä mainittujen periaatteiden ja Suomen lakien mukaisesti.",
+        "Noudatetaan turvallisen tilan periaatteita (alla)."
+      ],
+      "safetyTitle": "Algo ry:n turvallisemman tilan periaatteet:",
+      "safety": [
+        "Lopeta häiritsevä käytös ja pyydä välittömästi anteeksi.",
+        "Huolehdi, että kaikki pääsevät halutessaan osalliseksi ja tulevat kuulluiksi.",
+        "Älä häiritse ketään sanallisesti, koskettamalla tai tuijottamalla.",
+        "Jokainen saa osallistua ja jakaa asioita haluamassaan laajuudessa.",
+        "Anna tilaa ja käsittele arkoja asioita kunnioittavasti.",
+        "Älä tee oletuksia ihmisten ulkoisista ominaisuuksista.",
+        "Vältä syrjiviä stereotypioita puheessasi ja toiminnassasi.",
+        "Kunnioita henkilökohtaista tilaa ja muiden rajoja.",
+        "Puutumme asiattomaan ja häiritsevään käytökseen."
+      ],
+      "equalityTitle": "Yhdenvertaisuus:",
+      "equality": "Algo pyrkii luomaan jäsenilleen mahdollisimman turvallisen, luotettavan sekä yhdenvertaisen ympäristön jokaiselle jäsenelleen. Yliopistolakiin on kirjattu, että yliopiston tulee tarjota turvallinen opiskeluympäristö, jossa jokaisella on oikeus opiskella kokematta häirintää, kiusaamista ja syrjintää (Yliopistolaki 41§). Algo ry ei suvaitse tapahtumissaan kiusaamista, syrjimistä, häirintää tai muuta epäasiallista käytöstä missään muodossa. Haluamme olla edistämässä kaikille turvallista ja viihtyisää korkeakouluyhteisöä. Kiusaamiselta tai häirinnältä ei aina voi välttyä. Täten on ehdottoman tärkeää reagoida kiusaamistilanteisiin. Jyväskylän yliopistossa voit hakea apua esimerkiksi Hyviksiltä, jotka tarjoavat keskusteluapua ja ohjaavat tarvittaessa eteenpäin. Apua tarjoavat myös JYY:n häirintäyhteyshenkilöt tai sopo. Kaikki jaettu tieto on luottamuksellista, eikä siitä puhuta kenellekään ilman asianomaisen lupaa."
+    },
+    "pestit": {
+      "title": "Lyhyet kuvaukset hallituspesteistä",
+      "ps": "ps: Hallituksessa tehdään yhteistyössä muitakin kuin vain oman vastuualueen tehtäviä.",
+      "previous": "Aiemmat hallitukset näet",
+      "here": "täältä",
+      "roles": [
+        {
+          "title": "Puheenjohtaja",
+          "description": "on vastuussa hallituksen toiminnasta, johtaa hallituksen kokouksia sekä edustaa yleisesti kiltaa."
+        },
+        {
+          "title": "Varapuheenjohtaja",
+          "description": "sijaistaa puheenjohtajaa kokouksissa tämän estyessä, ja toimii tiiviissä yhteistyössä puheenjohtajan kanssa."
+        },
+        {
+          "title": "Sihteeri",
+          "description": "kirjoittaa kokouksissa pöytäkirjan (virallinen dokumentti kokouksissa läpikäytävistä asioista)."
+        },
+        {
+          "title": "Rahastonhoitaja",
+          "description": "maksaa laskuja, huolehtii kirjanpidosta ja vastaa killan pankkitilistä."
+        },
+        {
+          "title": "Yritysvastaava",
+          "description": "solmii ja ylläpitää yhteistyösopimuksia yritysten kanssa sekä vastaa yritystiimin toiminnasta."
+        },
+        {
+          "title": "Tapahtumavastaava",
+          "description": "ideoi ja järjestää tapahtumia sekä vastaa tapahtumatiimin toiminnasta."
+        },
+        {
+          "title": "Projektivastaavat",
+          "description": "vastaavat teekkariuteen liittyvistä projektiluontoisista tapahtumista kuten vuosijuhlista, lakinlaskijaisista ja kastajaisista."
+        },
+        {
+          "title": "Koulutuspoliittinen vastaava",
+          "description": "(kopo) huolehtii opiskelijoiden oikeuksien toteutumisesta ja ylläpitää suhteita yliopistoon."
+        },
+        {
+          "title": "Sosiaalipoliittinen vastaava",
+          "description": "(sopo) huolehtii opiskelijoiden edunvalvonnasta, hyvinvoinnista ja yhdenvertaisuudesta killan toiminnassa."
+        },
+        {
+          "title": "Kerhovastaava",
+          "description": "vastaa kommunikaatiosta kerhojen ja hallituksen välillä."
+        },
+        {
+          "title": "Viestintävastaava",
+          "description": "ylläpitää killan sosiaalisen median tilejä ja tiedottaa jäsenille tapahtumista ja muista tärkeistä asioista."
+        }
+      ]
+    },
+    "rekisteriseloste": {
+      "title": "Jäsenrekisteriseloste",
+      "sections": [
+        {
+          "title": "1. Rekisterinpitäjä",
+          "content": "Algo ry / IT-Tiedekunta\nPL 35 (Agora)\n40014 Jyväskylän yliopisto"
+        },
+        {
+          "title": "2. Rekisteristä vastaava yhteyshenkilö",
+          "content": "Algo ry:n sihteeri (sihteeri@algojkl.com)"
+        },
+        {
+          "title": "3. Rekisterin nimi",
+          "content": "Yhdistyksen jäsenrekisteri."
+        },
+        {
+          "title": "4. Oikeusperuste ja henkilötietojen käsittelyn tarkoitus",
+          "content": "EU:n yleisen tietosuoja-asetuksen mukainen oikeusperuste henkilötietojen käsittelylle on rekisterinpitäjän oikeutettu etu (jäsenyys). Henkilötietojen käsittelyn tarkoitus on yhteydenpito jäseniin, sekä jäsenyyden tarkistaminen, silloin kun sitä vaaditaan (esim. Sääntömääräinen kokous). Tietoja ei käytetä automatisoituun päätöksentekoon tai profilointiin. Yhdistyslain mukaan yhdistyksen hallituksen on pidettävä jäsenistä luetteloa."
+        },
+        {
+          "title": "5. Rekisterin tietosisältö",
+          "content": "Rekisteriin tallennettavia tietoja ovat: henkilön nimi, yhteystiedot (sähköpostiosoite), kotipaikkakunta."
+        },
+        {
+          "title": "6. Säännönmukaiset tietolähteet",
+          "content": "Rekisteriin tallennettavat tiedot saadaan jäseneltä www-lomakkeilla lähetetyistä viesteistä tai tapaamisessa."
+        },
+        {
+          "title": "7. Tietojen säännönmukaiset luovutukset ja tietojen siirto EU:n tai ETA:n ulkopuolelle",
+          "content": "Tietoja ei luovuteta säännönmukaisesti muille tahoille."
+        },
+        {
+          "title": "8. Rekisterin suojauksen periaatteet",
+          "content": "Rekisterin käsittelyssä noudatetaan huolellisuutta ja tietojärjestelmien avulla käsiteltävät tiedot suojataan asianmukaisesti. Kun rekisteritietoja säilytetään Internet-palvelimilla, niiden laitteiston fyysisestä ja digitaalisesta tietoturvasta huolehditaan asiaankuuluvasti. Rekisterinpitäjä huolehtii siitä, että tallennettuja tietoja sekä palvelimien käyttöoikeuksia ja muita henkilötietojen turvallisuuden kannalta kriittisiä tietoja käsitellään luottamuksellisesti ja vain niiden henkilöiden toimesta, joiden työnkuvaan se kuuluu."
+        },
+        {
+          "title": "9. Tarkastusoikeus ja oikeus vaatia tiedon korjaamista",
+          "content": "Jokaisella rekisterissä olevalla henkilöllä on oikeus tarkistaa rekisteriin tallennetut tietonsa ja vaatia mahdollisen virheellisen tiedon korjaamista tai puutteellisen tiedon täydentämistä. Mikäli henkilö haluaa tarkistaa hänestä tallennetut tiedot tai vaatia niihin oikaisua, pyyntö tulee lähettää kirjallisesti rekisterinpitäjälle. Rekisterinpitäjä voi pyytää tarvittaessa pyynnön esittäjää todistamaan henkilöllisyytensä. Rekisterinpitäjä vastaa asiakkaalle EU:n tietosuoja-asetuksessa säädetyssä ajassa."
+        },
+        {
+          "title": "10. Muut henkilötietojen käsittelyyn liittyvät oikeudet",
+          "content": "Rekisterissä olevalla henkilöllä on oikeus pyytää häntä koskevien henkilötietojen poistamiseen rekisteristä (”oikeus tulla unohdetuksi”). Niin ikään rekisteröidyillä on muut EU:n yleisen tietosuoja-asetuksen mukaiset oikeudet kuten henkilötietojen käsittelyn rajoittaminen tietyissä tilanteissa. Pyynnöt tulee lähettää kirjallisesti rekisterinpitäjälle. Rekisterinpitäjä voi pyytää tarvittaessa pyynnön esittäjää todistamaan henkilöllisyytensä. Rekisterinpitäjä vastaa asiakkaalle EU:n tietosuoja-asetuksessa säädetyssä ajassa"
+        }
+      ]
+    },
+    "toimari": {
+      "noImage": "Ei kuvaa"
+    },
+    "rekryt": {
+      "alt": "Rekryt",
+      "loading": "Ladataan rekryjä...",
+      "error": "Virhe ladatessa rekryjä",
+      "title": "Täällä julkaistaan avoimia rekryilmoituksia!",
+      "moreInfo": "Lisätietoja tästä!",
+      "empty": "Tällä hetkellä ei ole aktiivisia rekrytointeja."
+    },
+    "prevHalli": {
+      "boardTitle": "Hallitus {{year}}"
+    },
+    "salaisuudet": {
+      "prompt": "Syötä salasana päästäksesi sisältöön:",
+      "placeholder": "Salasana",
+      "loginButton": "Kirjaudu",
+      "wrongPassword": "Väärä salasana",
+      "serverError": "Palvelinvirhe: {{message}}",
+      "loading": "Ladataan sisältöä..."
+    },
+    "tapahtumat": {
+      "alt": "Tapahtumat",
+      "title": "Tulevat tapahtumat",
+      "description": "Tapahtumien ilmoittautumiset ja tarkemmat tiedot löytyvät Algo ry:n ilmoituskanavalta Telegramista. Algon Telegramin viestintäkanaviin liittyminen onnistuu sähköpostista löytyvistä jäsenkirjeistä tai kysymällä hallituslaisilta.",
+      "calendarTitle": "Google-kalenteri"
+    },
+    "yhteistyo": {
+      "alt": "Yhteistyö",
+      "title": "Hei! Kiinnostaako yhteistyö?",
+      "intro": "Algon kanssa voi tehdä yhteistyötä laidasta laitaan! Haluatko mainospaikan haalareista tai tukea tapahtumiamme? Vai kiinnostaisiko esitellä yritystäsi Jyväskylän DI-opiskelijoille?",
+      "contactUs": "Ota yhteyttä!",
+      "corporate": "Yritysyhteistyöt",
+      "events": "Tapahtumat",
+      "external": "Killan ulkosuhteet",
+      "otherIdeas": "Muita ideoita?",
+      "otherDescription": "Meille voi aina ehdottaa uusia yhteistyökuvioita!",
+      "otherContact": "Muista yhteistyökuvioista voi ottaa yhteyttä puheenjohtajaamme:",
+      "partnersTitle": "Yhteistyössä"
+    },
+    "yhteydenotto": {
+      "alt": "Yhteydenotto",
+      "general": {
+        "title": "Yleinen palautelomake",
+        "description": "Tänne saat kertoa palautetta - niin positiivista kuin negatiivistakin. Algon toiminnasta, nettisivuista tai mistä tahansa kiltaamme liittyvästä.",
+        "linkLabel": "Palautelomake"
+      },
+      "course": {
+        "title": "Kurssipalaute",
+        "description": "Algo ry:n yksi tärkeimpiä tehtäviä on edunvalvonta ja kilta pyrkii vaikuttamaan opetuksen kehittämiseen. Tällä lomakkeella voit antaa palautetta tietystä kurssista liittyen opetukseen, arviointiin tai mihin vaan. Tämä palaute ei korvaa yliopiston virallista tai opettajan antamaa kurssipalautelomaketta!",
+        "warning": "Tämä palaute ei korvaa yliopiston virallista tai opettajan antamaa kurssipalautelomaketta!",
+        "description2": "Tätä palautetta kerää ja käyttää Algon kopo ja puheenjohtaja. Tämän palautteen voit antaa täysin anonyymisti tai antaa yhteystietosi jos haluat että sinuun ollaan yhteydessä. Palautteet viedään kuitenkin eteenpäin täysin anonyymeinä.",
+        "linkLabel": "Kurssipalautelomake",
+        "linkPrefix": "Linkki lomakkeeseen"
+      }
+    }
+  },
+  "footer": {
+    "sections": {
+      "navigation": "NAVIGAATIO",
+      "staff": "TOIMIHENKILÖT",
+      "officialDocuments": "VIRALLISET DOKUMENTIT",
+      "members": "JÄSENILLE"
+    },
+    "contactTitle": "Yhteystiedot",
+    "addressLine1": "Mattilanniemi 2,",
+    "addressLine2": "40100 Jyväskylä",
+    "email": "pj@algojkl.com",
+    "vat": "Y-tunnus: 3297709-4",
+    "feedbackTitle": "Haluatko antaa meille palautetta?",
+    "feedbackDescription": "Se onnistuu, kun täytät alla olevan lomakkeen. Palautteet käsitellään anonyymisti.",
+    "feedbackLink": "Palautelomake"
+  }
+}

--- a/algojkl-frontend/src/locales/i18n.js
+++ b/algojkl-frontend/src/locales/i18n.js
@@ -1,0 +1,28 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import fiCommon from './fi/common.json'
+import enCommon from './en/common.json'
+
+const savedLanguage = localStorage.getItem('algo-language') || 'fi'
+
+const resources = {
+  fi: {
+    common: fiCommon,
+  },
+  en: {
+    common: enCommon,
+  },
+}
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: savedLanguage,
+  fallbackLng: 'fi',
+  ns: ['common'],
+  defaultNS: 'common',
+  interpolation: {
+    escapeValue: false,
+  },
+})
+
+export default i18n

--- a/algojkl-frontend/src/main.jsx
+++ b/algojkl-frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './locales/i18n'
 import App from './App.jsx'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 

--- a/algojkl-frontend/src/pages/AktiivitPage.jsx
+++ b/algojkl-frontend/src/pages/AktiivitPage.jsx
@@ -1,11 +1,7 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
-import {
-  starterImages,
-  tiimit,
-  muutAktiivit,
-  aktiivimerkit,
-} from '../PageData/aktiivitData'
+import { starterImages, aktiivimerkit } from '../PageData/aktiivitData'
 
 /**
  * AktiiviPage-komponentti
@@ -30,27 +26,27 @@ import {
  * se onnistuu muokkaamalla kyseistä tiedostoa.
  */
 const AktiiviPage = () => {
+  const { t } = useTranslation('common')
+  const teams = t('pages.aktiivit.teams', { returnObjects: true })
+  const otherRoles = t('pages.aktiivit.other', { returnObjects: true })
+
   return (
     <div className="aktiivi">
       <StarterImage
         desktopImage={starterImages.desktop}
         mobileImage={starterImages.mobile}
-        alt="Aktiivit"
+        alt={t('pages.aktiivit.alt')}
       />
       <div className="aktiivi-container">
         <div className="aktiivi-start">
-          <h1>MIKÄ IHMEEN AKTIIVI???</h1>
-          <p>
-            Aktiivit koostuvat kiltamme jäsenistä, jotka haluavat auttaa ja
-            vaikuttaa kiltamme toimintaan. Aktiivit auttavat hallituksemme
-            jäseniä matalalla kynnyksellä.
-          </p>
+          <h1>{t('pages.aktiivit.title')}</h1>
+          <p>{t('pages.aktiivit.description')}</p>
         </div>
 
         <div className="aktiivi-pestit">
-          <h2>AKTIIVIEN PESTIT</h2>
+          <h2>{t('pages.aktiivit.rolesTitle')}</h2>
           <ul>
-            {tiimit.map((tiimi, idx) => (
+            {teams.map((tiimi, idx) => (
               <li key={idx}>
                 <strong>{tiimi.title}</strong>
                 <ul>
@@ -75,7 +71,7 @@ const AktiiviPage = () => {
               </li>
             ))}
 
-            {muutAktiivit.map((m, idx) => (
+            {otherRoles.map((m, idx) => (
               <li key={idx}>
                 <strong>{m.title}</strong>
                 {m.subTasks && (
@@ -92,15 +88,17 @@ const AktiiviPage = () => {
         <br />
 
         <div className="aktiivi-consent">
-          <h3>Kiinnostuitko?</h3>
-          <p>Hae aktiiviksi täyttämällä alla olevan lomakkeen!</p>
+          <h3>{t('pages.aktiivit.interestedTitle')}</h3>
+          <p>{t('pages.aktiivit.interestedDescription')}</p>
           <button className="aktiivit-button">
-            <a href="https://forms.gle/iwLcCpC3bscAhbhN8">Hae Aktiiviksi</a>
+            <a href="https://forms.gle/iwLcCpC3bscAhbhN8">
+              {t('pages.aktiivit.applyButton')}
+            </a>
           </button>
         </div>
 
         <div className="aktiivi-container-merkit">
-          <h2>Aktiivimerkit</h2>
+          <h2>{t('pages.aktiivit.badgesTitle')}</h2>
           <div className="aktiivit-container-merkit-background">
             {aktiivimerkit.map((src, idx) => (
               <img key={idx} src={src} alt={`aktiivi_${idx}`} />

--- a/algojkl-frontend/src/pages/FuksitPage.jsx
+++ b/algojkl-frontend/src/pages/FuksitPage.jsx
@@ -1,17 +1,12 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
 import Panu from '../components/simple'
 import TutorList from '../components/Tutorlist'
 import Typewriter from '../components/Typewriter'
 import { useContentfulData } from '../services/useContentfulData'
 
-import {
-  starterImages,
-  ennenOpiskelua,
-  opintojenAlku,
-  kiltatoiminta,
-  jasenyys,
-} from '../PageData/fuksitData'
+import { starterImages } from '../PageData/fuksitData'
 
 /**
  * Fuksit-komponentti
@@ -32,27 +27,32 @@ import {
  */
 
 const Fuksit = () => {
+  const { t } = useTranslation('common')
   const { data, isLoading, error } = useContentfulData()
+  const beforeStudies = t('pages.fuksit.beforeStudies', { returnObjects: true })
+  const studyStart = t('pages.fuksit.studyStart', { returnObjects: true })
+  const guildActivity = t('pages.fuksit.guildActivity', { returnObjects: true })
+  const membership = t('pages.fuksit.membership', { returnObjects: true })
 
-  if (isLoading) return <p>Ladataan...</p>
-  if (error) return <p>Virhe ladattaessa tietoja!</p>
+  if (isLoading) return <p>{t('pages.fuksit.loading')}</p>
+  if (error) return <p>{t('pages.fuksit.error')}</p>
 
   return (
     <div>
       <StarterImage
         desktopImage={starterImages.desktop}
         mobileImage={starterImages.mobile}
-        alt="Fuksit"
+        alt={t('pages.fuksit.alt')}
       />
       <div className="Freshman-container">
-        <h1>Heippa teekkarifuksi!</h1>
+        <h1>{t('pages.fuksit.title')}</h1>
         <div className="fuksi-leveys">
           <div className="header">
             <div className="container-info">
-              <h1>Teekkarifuksi* ~: cd /fuksisyksy</h1>
+              <h1>{t('pages.fuksit.subtitle')}</h1>
               <div className="typewrite">
                 <Typewriter
-                  text="*Teekkarifuksi on ensimmäistä vuotta opiskeleva henkilö, joka teekkarikasteen suoritettuuan voi kutsua itseään teekkariksi."
+                  text={t('pages.fuksit.typewriter')}
                   prefix="$ "
                 />
               </div>
@@ -60,9 +60,9 @@ const Fuksit = () => {
             <Panu />
           </div>
 
-          <h2>Ennen opiskeluiden alkua:</h2>
+          <h2>{t('pages.fuksit.beforeStudiesTitle')}</h2>
           <ul>
-            {ennenOpiskelua.map((item, idx) => (
+            {beforeStudies.map((item, idx) => (
               <li key={idx}>
                 <strong>
                   {idx + 1}. {item.title}
@@ -82,25 +82,26 @@ const Fuksit = () => {
             ))}
           </ul>
           <p>
-            <i>Koko opiskeluajan tärkein asia: Seuraa sähköpostia!</i>
+            <i>{t('pages.fuksit.important')}</i>
           </p>
           <br />
 
-          <h2>Opintojen alku</h2>
-          {opintojenAlku.map((text, idx) => (
+          <h2>{t('pages.fuksit.studyStartTitle')}</h2>
+          {studyStart.map((text, idx) => (
             <p key={idx}>{text}</p>
           ))}
 
-          <h2>Kiltatoiminta</h2>
-          {kiltatoiminta.map((text, idx) => (
+          <h2>{t('pages.fuksit.guildActivityTitle')}</h2>
+          {guildActivity.map((text, idx) => (
             <p key={idx}>{text}</p>
           ))}
 
-          <h2>Jäsenyys</h2>
-          {jasenyys.map((text, idx) => (
+          <h2>{t('pages.fuksit.membershipTitle')}</h2>
+          {membership.map((text, idx) => (
             <p key={idx}>{text}</p>
           ))}
-          <h2>Tutorit 2026 esittäytyvät:</h2>
+          <h2>{t('pages.fuksit.tutorTitle')}</h2>
+          <p>{t('pages.fuksit.tutorNote')}</p>
           <br />
           <TutorList tutorit={data?.tutorit} />
         </div>

--- a/algojkl-frontend/src/pages/HakijatPage.jsx
+++ b/algojkl-frontend/src/pages/HakijatPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
-import { starterImages, tutkinnot } from '../PageData/hakijatData'
+import { starterImages } from '../PageData/hakijatData'
 
 /**
  * HakijatPage-komponentti
@@ -19,21 +20,20 @@ import { starterImages, tutkinnot } from '../PageData/hakijatData'
  * voidaan lisätä tarvittaessa hakijatData.js-tiedostoon.
  */
 const HakijatPage = () => {
+  const { t } = useTranslation('common')
+  const tutkinnot = t('pages.hakijat.tutkinnot', { returnObjects: true })
+
   return (
     <div>
       <StarterImage
         desktopImage={starterImages.desktop}
         mobileImage={starterImages.mobile}
-        alt="Hakijat"
+        alt={t('pages.hakijat.alt')}
       />
       <div className="hakijalle-container">
         <p>
-          Hienoa, että olet kiinnostunut opiskelusta Jyväskylän Yliopistossa!
-          Jyväskylän yliopisto tarjoaa kahta eri Diplomi-insinööri tutkintoa
-          IT-opiskelijoille:{' '}
-          <strong>
-            Tieto- ja ohjelmistotekniikka tai Teknologiajohtaminen.
-          </strong>
+          {t('pages.hakijat.intro')}{' '}
+          <strong>{t('pages.hakijat.degreeProgrammes')}</strong>
         </p>
 
         {tutkinnot.map((tutkinto, idx) => (
@@ -54,20 +54,16 @@ const HakijatPage = () => {
               ))}
             </ul>
             <p>
-              Lisätietoja {tutkinto.title.toLowerCase()} tutkinto-ohjelmasta
-              löydät <a href={tutkinto.link}>Jyväskylän yliopiston sivuilta.</a>
+              {t('pages.hakijat.moreInfoIntro', {
+                degree: tutkinto.title.toLowerCase(),
+              })}{' '}
+              <a href={tutkinto.link}>{t('pages.hakijat.moreInfoLink')}</a>
             </p>
           </div>
         ))}
 
-        <h3>Mikä ihmeen Algo ry?</h3>
-        <p>
-          Algo ry on Jyväskylän yliopiston tieto- ja ohjelmistotekniikan sekä
-          teknologiajohtamisen opiskelijoiden kilta. Killan tehtävänä on valvoa
-          jäsentensä etuja, järjestää monipuolisia tapahtumia sekä tehdä
-          yhteistyötä alan yritysten kanssa. Ennen kaikkea Algo on
-          jäsenistölleen yhteisö opintojen ajalle.
-        </p>
+        <h3>{t('pages.hakijat.aboutTitle')}</h3>
+        <p>{t('pages.hakijat.aboutDescription')}</p>
       </div>
     </div>
   )

--- a/algojkl-frontend/src/pages/HallihakuPage.jsx
+++ b/algojkl-frontend/src/pages/HallihakuPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import starterDesktop from '../images/Page_starters/16.jpg'
 import starterMobile from '../images/mobiili/18.png'
 import StarterImage from '../common/StarterImage'
@@ -12,20 +13,18 @@ import HallitusHaku from '../components/Hallihaku/HallitusHaku.jsx'
  * 3. HallitusHaku-komponentin, joka näyttää hakijat ja hallitukseen liittyvän sisällön (Contentfulista data).
  */
 const HallihakuPage = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Hallihaku"
+        alt={t('pages.hallihaku.alt')}
       />
       <div className="hallihaku-container-start">
-        <h1>Hallitushaku 2027</h1>
-        <p>
-          Hallitushaku vuodelle 2027 on alkanut! Täältä pääset tutustumaan
-          hakijoihin. Ohjeistus hallitukseen hakemiseen löytyy Algon
-          ilmoituskanavalta.
-        </p>
+        <h1>{t('pages.hallihaku.title')}</h1>
+        <p>{t('pages.hallihaku.description')}</p>
       </div>
       <HallitusHaku />
     </div>

--- a/algojkl-frontend/src/pages/HomePage.jsx
+++ b/algojkl-frontend/src/pages/HomePage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import Carousel from '../components/Carousel/carousel.jsx'
 import EventCards from '../components/Events/EventCards.jsx'
 import DiamondLogos from '../components/diamondLogos.jsx'
@@ -17,6 +18,8 @@ import Typewriter from '../components/Typewriter.jsx'
  */
 
 const HomePage = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <Carousel />
@@ -24,20 +27,17 @@ const HomePage = () => {
         <div className="container-info">
           <div>
             <p className="terminal">AlgoWeb$: cat Algo.ry </p>
-            <Typewriter
-              text="Algo ry on vuonna 2022 perustettu kilta, joka yhdistää Jyväskylän yliopiston tieto- ja ohjelmistotekniikan sekä teknologiajohtamisen opiskelijat."
-              prefix="$ "
-            />
+            <Typewriter text={t('pages.home.introText')} prefix="$ " />
           </div>
         </div>
         <div className="events">
-          <h2>TULEVAT TAPAHTUMAT</h2>
+          <h2>{t('pages.home.upcomingEvents')}</h2>
           <EventCards />
         </div>
 
         <div className="diamond-partners">
           <IoDiamondSharp />
-          <h2>TIMANTTIKUMPPANIT</h2>
+          <h2>{t('pages.home.diamondPartners')}</h2>
           <IoDiamondSharp />
         </div>
         <DiamondLogos />

--- a/algojkl-frontend/src/pages/KansainvalisyysPage.jsx
+++ b/algojkl-frontend/src/pages/KansainvalisyysPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
 import Vaihtovuosi from '../components/kansainvalisyys/Vaihtovuosi'
 import Vaihtovinkit from '../components/kansainvalisyys/Vaihtovinkit'
@@ -21,15 +22,17 @@ import starterMobile from '../images/mobiili/20.png'
  */
 
 const KansainvalisyysPage = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Kansainvälisyys"
+        alt={t('pages.kansainvalisyys.alt')}
       />
       <div className="kansainvalisyys-container">
-        <h1>Algolaisen vaihtovinkit ja linkit</h1>
+        <h1>{t('pages.kansainvalisyys.title')}</h1>
         <Vaihtovuosi />
         <Vaihtovinkit />
         <VaihtoOhjelmat />

--- a/algojkl-frontend/src/pages/KerhotoimintaPage.jsx
+++ b/algojkl-frontend/src/pages/KerhotoimintaPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import starterDesktop from '../images/Page_starters/15.jpg'
 import starterMobile from '../images/mobiili/17.png'
 import StarterImage from '../common/StarterImage'
 
-import { kerhotoimintaData } from '../PageData/kerhotoimintaData'
 import KerhotSection from '../components/Kerhotoiminta/KerhotSection'
 import NewClubSection from '../components/Kerhotoiminta/NewClubSection'
 import SupportSection from '../components/Kerhotoiminta/SupportSection'
@@ -19,18 +19,23 @@ import SupportSection from '../components/Kerhotoiminta/SupportSection'
  * - SupportSection: kerhoille tarjottava tuki
  */
 const KerhotoimintaPage = () => {
-  const { title, intro, kerhot, newClub, support } = kerhotoimintaData
+  const { t } = useTranslation('common')
+  const kerhot = Object.values(
+    t('pages.kerhotoiminta.kerhot', { returnObjects: true }),
+  )
+  const newClub = t('pages.kerhotoiminta.newClub', { returnObjects: true })
+  const support = t('pages.kerhotoiminta.support', { returnObjects: true })
 
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt={title}
+        alt={t('pages.kerhotoiminta.title')}
       />
       <div className="kerhotoiminta-container">
-        <h1>{title}</h1>
-        <p>{intro}</p>
+        <h1>{t('pages.kerhotoiminta.title')}</h1>
+        <p>{t('pages.kerhotoiminta.intro')}</p>
 
         <KerhotSection kerhot={kerhot} />
         <NewClubSection newClub={newClub} />

--- a/algojkl-frontend/src/pages/KunniagalleriaPage.jsx
+++ b/algojkl-frontend/src/pages/KunniagalleriaPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
 import halli2022 from '../images/halli_2022.png'
 
@@ -22,21 +23,20 @@ import starterMobile from '../images/mobiili/14.png'
  * ja perustajajäsenet/hallituksen 2022 kuvan kanssa.
  */
 const KunniagalleriaPage = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Kunniagalleria"
+        alt={t('pages.kunniagalleria.alt')}
       />
 
       <div className="kunnia-container">
-        <h2>Algo ry:n kunniajäsenet</h2>
+        <h2>{t('pages.kunniagalleria.honoraryTitle')}</h2>
         <p>
-          <i>
-            Kunniajäsen on killan toimintaa erityisen ansiokkaasti tukenut
-            henkilö. Kunniajäsenyys on Algon korkein kunnianosoitus.
-          </i>
+          <i>{t('pages.kunniagalleria.honoraryDescription')}</i>
         </p>
         <div className="kunniajasenet">
           {kunniajasenet.map((p, idx) => (
@@ -46,21 +46,17 @@ const KunniagalleriaPage = () => {
       </div>
 
       <div className="kunnia-container">
-        <h2>Vuoden Algolainen - palkinnon voittajat</h2>
+        <h2>{t('pages.kunniagalleria.yearlyTitle')}</h2>
         <p>
-          <i>
-            Vuoden algolainen on jäsenten äänestyksessä päättämä, joka on
-            osoittanut merkittävää kiinnostusta yhdistyksen toimintaa kohtaan ja
-            edistänyt jäsenten välistä yhteishenkeä.
-          </i>
+          <i>{t('pages.kunniagalleria.yearlyDescription')}</i>
         </p>
         <VuodenAlgolaiset people={vuodenAlgolaiset} />
       </div>
       <Perustajat image={halli2022} members={perustajat2022} year={2022} />
       <div className="kunnia-container">
         <p>
-          Muut edelliset hallitukset näet{' '}
-          <a href="/entiset-hallitukset">täältä</a>
+          {t('pages.kunniagalleria.previousBoards')}{' '}
+          <a href="/entiset-hallitukset">{t('pages.kunniagalleria.here')}</a>
         </p>
       </div>
     </div>

--- a/algojkl-frontend/src/pages/NotFound.jsx
+++ b/algojkl-frontend/src/pages/NotFound.jsx
@@ -1,19 +1,22 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 
 /**
  *  Palauttaa 404 Not Found -sivun, jos etsitään sivua, jota ei ole olemassa.
  */
 const NotFound = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div className="notfound-container">
       <h1>404</h1>
-      <h2>Sivua ei löytynyt</h2>
+      <p className="notfound-title">{t('pages.notFound.title')}</p>
       <p>
-        Etsimääsi sivua ei ole olemassa. Tarkista osoite tai palaa etusivulle.
+        {t('pages.notFound.description')}
       </p>
       <Link to="/" className="notfound-link">
-        Palaa etusivulle
+        {t('pages.notFound.backHome')}
       </Link>
     </div>
   )

--- a/algojkl-frontend/src/pages/RekisteriselostePage.jsx
+++ b/algojkl-frontend/src/pages/RekisteriselostePage.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
 import starterDesktop from '../images/Page_starters/10.jpg'
 import starterMobile from '../images/mobiili/12.png'
-import { rekisteriselosteSections } from '../PageData/rekisteriselosteData.jsx'
 
 /**
  * Yksittäinen osio rekisteriselosteesta
@@ -13,7 +13,7 @@ import { rekisteriselosteSections } from '../PageData/rekisteriselosteData.jsx'
 const Section = ({ title, content }) => (
   <div className="rekisteri-section">
     <h2>{title}</h2>
-    {content}
+    <p>{content}</p>
   </div>
 )
 
@@ -21,24 +21,29 @@ const Section = ({ title, content }) => (
  * RekisteriselostePage-komponentti
  * Tämä komponentti renderöi jäsenrekisteriseloste-sivun, joka sisältää:
  * 1. StarterImage-komponentin pääbannerin kuvan renderöintiin (desktop ja mobile).
- * 2. Jäsenrekisteriselosteen eri osiot, jotka on määritelty rekisteriselosteData.js-tiedostossa.
+ * 2. Jäsenrekisteriselosteen eri osiot, jotka on määritelty lokalisaatiotiedostossa.
  */
-const RekisteriselostePage = () => (
-  <div>
-    <StarterImage
-      desktopImage={starterDesktop}
-      mobileImage={starterMobile}
-      alt="Seloste"
-    />
-    <div className="seloste-container">
-      <h1>Jäsenrekisteriseloste</h1>
-      <div className="seloste-container-items">
-        {rekisteriselosteSections.map((section, idx) => (
-          <Section key={idx} title={section.title} content={section.content} />
-        ))}
+const RekisteriselostePage = () => {
+  const { t } = useTranslation('common')
+  const sections = t('pages.rekisteriseloste.sections', { returnObjects: true })
+
+  return (
+    <div>
+      <StarterImage
+        desktopImage={starterDesktop}
+        mobileImage={starterMobile}
+        alt={t('pages.rekisteriseloste.title')}
+      />
+      <div className="seloste-container">
+        <h1>{t('pages.rekisteriseloste.title')}</h1>
+        <div className="seloste-container-items">
+          {sections.map((section, idx) => (
+            <Section key={idx} title={section.title} content={section.content} />
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default RekisteriselostePage

--- a/algojkl-frontend/src/pages/RekrytPage.jsx
+++ b/algojkl-frontend/src/pages/RekrytPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import starterDesktop from '../images/Page_starters/16.jpg'
 import starterMobile from '../images/mobiili/18.png'
 import { useContentfulData } from '../services/useContentfulData'
@@ -12,20 +13,21 @@ import StarterImage from '../common/StarterImage'
  * 3. Dynaamisen listan avoimista rekryilmoituksista, jotka haetaan Contentfulista.
  */
 const RekrytPage = () => {
+  const { t } = useTranslation('common')
   const { data, isLoading, error } = useContentfulData()
 
-  if (isLoading) return <p>Ladataan rekryjä...</p>
-  if (error) return <p>Virhe ladatessa rekryjä</p>
+  if (isLoading) return <p>{t('pages.rekryt.loading')}</p>
+  if (error) return <p>{t('pages.rekryt.error')}</p>
 
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Seloste"
+        alt={t('pages.rekryt.alt')}
       />
       <div className="rekryt-container">
-        <h1>Täällä julkaistaan avoimia rekryilmotuksia!</h1>
+        <h1>{t('pages.rekryt.title')}</h1>
         {data?.hiring && data.hiring.length > 0 ? (
           data.hiring.map((item, index) => {
             const kuvaUrl =
@@ -61,7 +63,7 @@ const RekrytPage = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    Lisätietoja tästä!
+                    {t('pages.rekryt.moreInfo')}
                   </a>
                 ) : (
                   <p style={{ color: 'red' }}></p>
@@ -70,7 +72,7 @@ const RekrytPage = () => {
             )
           })
         ) : (
-          <p>Tällä hetkellä ei ole aktiivisia rekrytointeja.</p>
+          <p>{t('pages.rekryt.empty')}</p>
         )}
       </div>
     </div>

--- a/algojkl-frontend/src/pages/SaannotPage.jsx
+++ b/algojkl-frontend/src/pages/SaannotPage.jsx
@@ -1,24 +1,27 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import StarterImage from '../common/StarterImage'
 import starterDesktop from '../images/Page_starters/8.jpg'
 import starterMobile from '../images/mobiili/10.png'
 import Section from '../components/Saannot/Section'
-import { saannotSections } from '../PageData/saannotData.jsx'
 
 /**
  * SäännötPage-komponentti
- * Renderöi Algo ry:n säännöt käyttäen dataa ja Section-komponenttia.
+ * Renderöi Algo ry:n säännöt käyttäen lokalisoitua dataa ja Section-komponenttia.
  */
 const RulePage = () => {
+  const { t } = useTranslation('common')
+  const saannotSections = t('pages.saannot.sections', { returnObjects: true })
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Säännöt"
+        alt={t('pages.saannot.alt')}
       />
       <div className="saannot-container">
-        <h1>Algo ry:n säännöt</h1>
+        <h1>{t('pages.saannot.title')}</h1>
         <div className="saannot-container-items">
           {saannotSections.map((section, idx) => (
             <Section

--- a/algojkl-frontend/src/pages/SalaisuudetPage.jsx
+++ b/algojkl-frontend/src/pages/SalaisuudetPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import starterDesktop from '../images/Page_starters/21.jpg'
 import starterMobile from '../images/mobiili/21.png'
 import StarterImage from '../common/StarterImage'
@@ -11,6 +12,7 @@ import StarterImage from '../common/StarterImage'
  * 3. Lomakkeen salasanan syöttämistä varten ja virheilmoitukset väärästä salasanasta tai palvelinvirheistä.
  */
 const SalaisuudetPage = () => {
+  const { t } = useTranslation('common')
   const [password, setPassword] = useState('')
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [error, setError] = useState('')
@@ -34,10 +36,10 @@ const SalaisuudetPage = () => {
         setIsAuthenticated(true)
         setError('')
       } else {
-        setError(data.message || 'Väärä salasana')
+        setError(data.message || t('pages.salaisuudet.wrongPassword'))
       }
     } catch (err) {
-      setError('Palvelinvirhe: ' + err.message)
+      setError(t('pages.salaisuudet.serverError', { message: err.message }))
     }
   }
 
@@ -50,15 +52,15 @@ const SalaisuudetPage = () => {
           alt="Seloste"
         />
         <div className="login-container">
-          <h2>Syötä salasana päästäksesi sisältöön:</h2>
+          <h2>{t('pages.salaisuudet.prompt')}</h2>
           <form onSubmit={handleSubmit}>
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="Salasana"
+              placeholder={t('pages.salaisuudet.placeholder')}
             />
-            <button type="submit">Kirjaudu</button>
+            <button type="submit">{t('pages.salaisuudet.loginButton')}</button>
           </form>
           {error && <p style={{ color: 'red' }}>{error}</p>}
         </div>
@@ -66,7 +68,7 @@ const SalaisuudetPage = () => {
     )
   }
 
-  if (!content) return <p>Ladataan sisältöä...</p>
+  if (!content) return <p>{t('pages.salaisuudet.loading')}</p>
 
   return (
     <div>

--- a/algojkl-frontend/src/pages/TapahtumatPage.jsx
+++ b/algojkl-frontend/src/pages/TapahtumatPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import starterDesktop from '../images/Page_starters/3.jpg'
 import starterMobile from '../images/mobiili/4.png'
 import StarterImage from '../common/StarterImage'
@@ -12,23 +13,20 @@ const Calendar_key = import.meta.env.VITE_CALENDAR_API
  * 2. Tapahtumatiedot ja upotetun Google-kalenterin, josta käyttäjät voivat tarkastella tulevia tapahtumia.
  */
 const Events = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Events"
+        alt={t('pages.tapahtumat.alt')}
       />
       <div className="event-container">
-        <h2>Tulevat tapahtumat</h2>
-        <p>
-          Tapahtumien ilmoittautumiset ja tarkemmat tiedot löytyvät Algo ry:n
-          ilmoituskanavalta Telegramista. Algon Telegramin viestintäkanaviin
-          liittyminen onnistuu sähköpostista löytyvistä jäsenkirjeistä tai
-          kysymällä hallituslaisilta.
-        </p>
+        <h2>{t('pages.tapahtumat.title')}</h2>
+        <p>{t('pages.tapahtumat.description')}</p>
         <iframe
-          title="Google calendar"
+          title={t('pages.tapahtumat.calendarTitle')}
           src={Calendar_key}
           className="google-calendar"
           frameBorder="0"

--- a/algojkl-frontend/src/pages/VujuPage.jsx
+++ b/algojkl-frontend/src/pages/VujuPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import StarterImage from '../common/StarterImage'
 import starterDesktop from '../images/Page_starters/vujut.jpg'
 import starterMobile from '../images/mobiili/vujut_m.jpg'
-import { vujuContent } from '../PageData/vujuData'
 /**
  *  Vujut-sivu
  * Tämä komponentti renderöi Vujut-sivun sisällön.
@@ -11,16 +11,22 @@ import { vujuContent } from '../PageData/vujuData'
  * 1. Starter-kuva (desktop ja mobiili)
  * 2. Vuosijuhlaetiketti-osio, joka kertoo vuosijuhlien käytänteistä, pukeutumisesta,
  *    arvokkaasta juhlakäyttäytymisestä, juhlan kulusta sekä akateemisesta silliaamiaisesta.
- * refraktorointi kesken
  */
 
 const Vujut = () => {
+  const { t } = useTranslation('common')
+  const vujuContent = {
+    title: t('pages.vuju.title'),
+    intro: t('pages.vuju.intro'),
+    sections: t('pages.vuju.sections', { returnObjects: true }),
+  }
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Events"
+        alt={t('pages.vuju.alt')}
       />
       <div className="vuju-container-start">
         <h1>{vujuContent.title}</h1>

--- a/algojkl-frontend/src/pages/YhteistyöPage.jsx
+++ b/algojkl-frontend/src/pages/YhteistyöPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import CollabCards from '../components/collabLogos'
 
 import starterDesktop from '../images/Page_starters/2.jpg'
@@ -18,40 +19,38 @@ import StarterImage from '../common/StarterImage'
  * 3. CollabCards-komponentti, joka esittelee yhteistyökumppaneiden logot
  */
 const Collab = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Yhteistyö"
+        alt={t('pages.yhteistyo.alt')}
       />
       <div className="collab-container">
-        <h1>Hei! Kiinnostaako yhteistyö?</h1>
-        <p>
-          Algon kanssa voi tehdä yhteistyötä laidasta laitaan! Haluatko
-          mainospaikan haalareista tai tukea tapahtumiamme? Vai kiinnostaisiko
-          esitellä yritystäsi Jyväskylän DI-opiskelijoille?
-        </p>
-        <h3>Ota yhteyttä!</h3>
+        <h1>{t('pages.yhteistyo.title')}</h1>
+        <p>{t('pages.yhteistyo.intro')}</p>
+        <h3>{t('pages.yhteistyo.contactUs')}</h3>
         <br />
         <div className="collab-container-flex">
           <div>
             <img src={collab_icon} alt="yhteistyö icon" />
-            <h3>Yritysyhteistyöt</h3>
+            <h3>{t('pages.yhteistyo.corporate')}</h3>
             <h4>
               <strong>yritys@algojkl.com</strong>
             </h4>
           </div>
           <div>
             <img src={event_icon} alt="event icon" />
-            <h3>Tapahtumat</h3>
+            <h3>{t('pages.yhteistyo.events')}</h3>
             <h4>
               <strong>tapahtumat@algojkl.com</strong>
             </h4>
           </div>
           <div>
             <img src={ulkosuhteet_icon} alt="ulkosuhteet_icon" />
-            <h3>Killan ulkosuhteet</h3>
+            <h3>{t('pages.yhteistyo.external')}</h3>
             <h4>
               {' '}
               <strong>vpj@algojkl.com</strong>
@@ -59,17 +58,18 @@ const Collab = () => {
           </div>
           <div className="collab-overflow">
             <img src={lamppu_icon} alt="muut icon" />
-            <h3>Muita ideoita?</h3>
+            <h3>{t('pages.yhteistyo.otherIdeas')}</h3>
             <h4>
-              Meille voi aina ehdottaa uusia yhteistyökuvioita! <br />
-              Muista yhteistyökuvioista voi ottaa yhteyttä puheenjohtajaamme:{' '}
+              {t('pages.yhteistyo.otherDescription')}
+              <br />
+              {t('pages.yhteistyo.otherContact')}{' '}
               <br />
               <br />
               <strong>pj@algojkl.com</strong>
             </h4>
           </div>
         </div>
-        <h2>Yhteistyössä</h2>
+        <h2>{t('pages.yhteistyo.partnersTitle')}</h2>
       </div>
       <CollabCards />
     </div>

--- a/algojkl-frontend/src/pages/YhteydenottoPage.jsx
+++ b/algojkl-frontend/src/pages/YhteydenottoPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import starterDesktop from '../images/Page_starters/17.jpg'
 import starterMobile from '../images/mobiili/19.png'
 import StarterImage from '../common/StarterImage'
@@ -17,12 +18,14 @@ import YleinenPalaute from '../components/yhteydenotto/YleinenPalaute'
  * 4. Yleinen palautelomake-osio, jossa on linkki yleiseen palautelomakkeeseen
  */
 const YhteydenottoPage = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div>
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Yhteydenotto"
+        alt={t('pages.yhteydenotto.alt')}
       />
       <div className="yhteydenotto-container">
         <Kurssipalaute />

--- a/algojkl-frontend/src/pages/hallitusPage.jsx
+++ b/algojkl-frontend/src/pages/hallitusPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import starterDesktop from '../images/Page_starters/6.jpg'
 import starterMobile from '../images/mobiili/8.png'
@@ -25,9 +26,10 @@ import { hallitusOrder } from '../utils/hallitusOrder'
  */
 
 const HallitusPage = () => {
+  const { t } = useTranslation('common')
   const { data, isLoading, error } = useContentfulData()
-  if (isLoading) return <p>Ladataan...</p>
-  if (error) return <p>Virhe ladattaessa tietoja.</p>
+  if (isLoading) return <p>{t('pages.hallitus.loading')}</p>
+  if (error) return <p>{t('pages.hallitus.error')}</p>
 
   const sortedHallitus = [...data.hallitus].sort((a, b) => {
     const orderA = hallitusOrder[a.pesti] ?? 99
@@ -42,27 +44,31 @@ const HallitusPage = () => {
       <StarterImage
         desktopImage={starterDesktop}
         mobileImage={starterMobile}
-        alt="Hallitus"
+        alt={t('pages.hallitus.alt')}
       />
       <div className="hallitus">
-        <h1>Hallitus {date}</h1>
+        <h1>{t('pages.hallitus.title', { year: date })}</h1>
         <div className="hallitus-grid">
           {sortedHallitus.map((member) => (
             <HallitusCard key={member.id} member={member} />
           ))}
         </div>
-        <div className='hallitus-contact'>
-        <p>
-          Psst. mikäli haluat tavoittaa koko hallituksen yhdellä viestillä, voit lähettää sähköpostia osoitteeseen
-          <a href="mailto:hallitus@algojkl.com"> hallitus@algojkl.com</a>.
-          Yksittäisiin hallitusjäseniin saat yhteyden sähköpostitse osoitteilla
-          <a href="mailto:etunimi.sukunimi@algojkl.com"> etunimi.sukunimi@algojkl.com</a>.
-        </p>
+        <div className="hallitus-contact">
+          <p>
+            {t('pages.hallitus.contactIntro')}{' '}
+            <a href="mailto:hallitus@algojkl.com"> hallitus@algojkl.com</a>.
+            {' '}
+            {t('pages.hallitus.contactMembers')}{' '}
+            <a href="mailto:etunimi.sukunimi@algojkl.com">
+              {' '}
+              etunimi.sukunimi@algojkl.com
+            </a>.
+          </p>
         </div>
       </div>
       <PestitDescription />
       <div className="toimarit">
-        <h2>Toimihenkilöt {date}</h2>
+        <h2>{t('pages.hallitus.staffTitle', { year: date })}</h2>
         <div className="toimarit-grid">
           {data.toimarit.map((toimari) => (
             <Toimari key={toimari.id} member={toimari} />

--- a/algojkl-frontend/src/pages/prevHalliPage.jsx
+++ b/algojkl-frontend/src/pages/prevHalliPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { hallitukset } from '../PageData/prevHallitusData'
 import HallitusCard from '../components/prevHallicard'
 
@@ -9,11 +10,13 @@ import HallitusCard from '../components/prevHallicard'
  * Käyttää HallitusCard-komponenttia jokaisen hallituksen esittämiseen.
  */
 const PrevHalli = () => {
+  const { t } = useTranslation('common')
+
   return (
     <div className="prev-hallitus">
       {hallitukset.map((hallitus) => (
         <div key={hallitus.year}>
-          <h3>Hallitus {hallitus.year}</h3>
+          <h3>{t('pages.prevHalli.boardTitle', { year: hallitus.year })}</h3>
           <HallitusCard
             year={hallitus.year}
             image={hallitus.image}

--- a/algojkl-frontend/src/services/useContentfulData.jsx
+++ b/algojkl-frontend/src/services/useContentfulData.jsx
@@ -91,6 +91,7 @@ const fetchContentfulData = async () => {
       pesti: item.fields.pesti || null,
       telegram: item.fields.telegram || null,
       kuva: item.fields.kuva?.fields?.file?.url || null,
+      email: item.fields.email || null,
     })),
   }
 }


### PR DESCRIPTION
### Support for I18n library
- Added support for toggling en/fi
- Added i18n depency 
- Added locales/fi and locales/en and all supported tags in these files. All hardcoded info are located in these files.

### Modifications
- Modified every page and removed all hardcoded texts. 
- Modified CSS and added css for the toggle in navbar. 